### PR TITLE
Task 1551186043 - Idf parser retrieves Array Express display name

### DIFF
--- a/base/src/main/java/uk/ac/ebi/atlas/experimentimport/condensedSdrf/IdfParser.java
+++ b/base/src/main/java/uk/ac/ebi/atlas/experimentimport/condensedSdrf/IdfParser.java
@@ -12,6 +12,7 @@ import java.util.Arrays;
 public class IdfParser {
     private static final String INVESTIGATION_TITLE_ID = "Investigation Title";
     private static final String PUBMED_ID = "PubMed ID";
+    private static final String AE_EXPERIMENT_DISPLAY_NAME = "Comment[AEExperimentDisplayName]";
 
     private IdfStreamerFactory idfReaderFactory;
 
@@ -22,15 +23,26 @@ public class IdfParser {
 
     public ImmutablePair<String, ImmutableSet<String>> parse(String experimentAccession) {
 
-        try (TsvStreamer titleIdfStreamer = idfReaderFactory.create(experimentAccession);
+        try (TsvStreamer aeTitleIdfStreamer = idfReaderFactory.create(experimentAccession);
+             TsvStreamer titleIdfStreamer = idfReaderFactory.create(experimentAccession);
              TsvStreamer pubmedIdfStreamer = idfReaderFactory.create(experimentAccession)) {
-            String title =
-                    titleIdfStreamer.get()
-                            .filter(line -> line.length > 1)
-                            .filter(line -> INVESTIGATION_TITLE_ID.equalsIgnoreCase(line[0].trim()))
-                            .map(line -> line[1])
-                            .findFirst()
-                            .orElse("");
+            String title = "";
+
+            title = aeTitleIdfStreamer.get()
+                        .filter(line -> line.length > 1)
+                        .filter(line -> AE_EXPERIMENT_DISPLAY_NAME.equalsIgnoreCase(line[0].trim()))
+                        .map(line-> line[1])
+                        .findFirst()
+                        .orElse("");
+
+            if(title.isEmpty()) {
+                title = titleIdfStreamer.get()
+                                .filter(line -> line.length > 1)
+                                .filter(line -> INVESTIGATION_TITLE_ID.equalsIgnoreCase(line[0].trim()))
+                                .map(line -> line[1])
+                                .findFirst()
+                                .orElse("");
+            }
 
             ImmutableSet<String> pubmedIds = ImmutableSet.copyOf(
                     pubmedIdfStreamer.get()

--- a/base/src/main/java/uk/ac/ebi/atlas/experimentimport/condensedSdrf/IdfParser.java
+++ b/base/src/main/java/uk/ac/ebi/atlas/experimentimport/condensedSdrf/IdfParser.java
@@ -7,8 +7,6 @@ import uk.ac.ebi.atlas.commons.readers.TsvStreamer;
 import javax.inject.Inject;
 import javax.inject.Named;
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 

--- a/base/src/main/java/uk/ac/ebi/atlas/experimentimport/condensedSdrf/IdfParser.java
+++ b/base/src/main/java/uk/ac/ebi/atlas/experimentimport/condensedSdrf/IdfParser.java
@@ -32,9 +32,9 @@ public class IdfParser {
             Map<String, String> titles = titleIdfStreamer.get()
                     .filter(line -> line.length > 1)
                     .filter(line -> AE_EXPERIMENT_DISPLAY_NAME.equalsIgnoreCase(line[0].trim()) || INVESTIGATION_TITLE_ID.equalsIgnoreCase(line[0].trim()))
-                    .collect(Collectors.toMap(line -> line[0], line-> line[1]));
+                    .collect(Collectors.toMap(line -> line[0].toUpperCase().trim(), line-> line[1]));
 
-            String title = titles.getOrDefault(AE_EXPERIMENT_DISPLAY_NAME, titles.getOrDefault(INVESTIGATION_TITLE_ID, ""));
+            String title = titles.getOrDefault(AE_EXPERIMENT_DISPLAY_NAME.toUpperCase(), titles.getOrDefault(INVESTIGATION_TITLE_ID.toUpperCase(), ""));
 
             ImmutableSet<String> pubmedIds = ImmutableSet.copyOf(
                     pubmedIdfStreamer.get()

--- a/base/src/test/java/uk/ac/ebi/atlas/experimentimport/condensedSdrf/IdfParserTest.java
+++ b/base/src/test/java/uk/ac/ebi/atlas/experimentimport/condensedSdrf/IdfParserTest.java
@@ -42,9 +42,6 @@ public class IdfParserTest {
     private TsvStreamer pubmedsIdfStreamerMock;
 
     @Mock
-    private TsvStreamer aeTitleIdfStreamerMock;
-
-    @Mock
     private IdfStreamerFactory idfStreamerFactoryMock;
 
     @InjectMocks
@@ -52,12 +49,12 @@ public class IdfParserTest {
 
     @Before
     public void setUp() {
-        when(idfStreamerFactoryMock.create(E_MTAB_513)).thenReturn(aeTitleIdfStreamerMock, titleIdfStreamerMock, pubmedsIdfStreamerMock);
+        when(idfStreamerFactoryMock.create(E_MTAB_513)).thenReturn(titleIdfStreamerMock, pubmedsIdfStreamerMock);
     }
 
     @Test
     public void parse() {
-        when(aeTitleIdfStreamerMock.get()).thenReturn(Stream.of(E_MTAB_513_IDF_TXT));
+        when(titleIdfStreamerMock.get()).thenReturn(Stream.of(E_MTAB_513_IDF_TXT));
         when(pubmedsIdfStreamerMock.get()).thenReturn(Stream.of(E_MTAB_513_IDF_TXT));
 
         Pair<String, ImmutableSet<String>> idfParserOutput = subject.parse(E_MTAB_513);
@@ -68,7 +65,7 @@ public class IdfParserTest {
 
     @Test
     public void parseNoPubmedIds() {
-        when(aeTitleIdfStreamerMock.get()).thenReturn(Stream.<String[]>of(E_MTAB_513_IDF_TXT[0], E_MTAB_513_IDF_TXT[1]));
+        when(titleIdfStreamerMock.get()).thenReturn(Stream.<String[]>of(E_MTAB_513_IDF_TXT[0], E_MTAB_513_IDF_TXT[1]));
         when(pubmedsIdfStreamerMock.get()).thenReturn(Stream.<String[]>of(E_MTAB_513_IDF_TXT[0], E_MTAB_513_IDF_TXT[1]));
 
         Pair<String, ImmutableSet<String>> idfParserOutput = subject.parse(E_MTAB_513);
@@ -80,7 +77,6 @@ public class IdfParserTest {
     @Test
     public void parseNoAeDisplayName() {
         when(titleIdfStreamerMock.get()).thenReturn(Stream.<String[]>of(E_MTAB_513_IDF_TXT[0], E_MTAB_513_IDF_TXT[2]));
-        when(aeTitleIdfStreamerMock.get()).thenReturn(Stream.<String[]>of(E_MTAB_513_IDF_TXT[0], E_MTAB_513_IDF_TXT[2]));
         when(pubmedsIdfStreamerMock.get()).thenReturn(Stream.<String[]>of(E_MTAB_513_IDF_TXT[0], E_MTAB_513_IDF_TXT[2]));
 
         Pair<String, ImmutableSet<String>> idfParserOutput = subject.parse(E_MTAB_513);
@@ -92,7 +88,6 @@ public class IdfParserTest {
     @Test
     public void parseNoAeDisplayNameNoTitle() {
         when(titleIdfStreamerMock.get()).thenReturn(Stream.<String[]>of(E_MTAB_513_IDF_TXT[2]));
-        when(aeTitleIdfStreamerMock.get()).thenReturn(Stream.<String[]>of(E_MTAB_513_IDF_TXT[2]));
         when(pubmedsIdfStreamerMock.get()).thenReturn(Stream.<String[]>of(E_MTAB_513_IDF_TXT[2]));
 
         Pair<String, ImmutableSet<String>> idfParserOutput = subject.parse(E_MTAB_513);
@@ -104,7 +99,6 @@ public class IdfParserTest {
     @Test
     public void parseNothing() {
         when(titleIdfStreamerMock.get()).thenReturn(Stream.empty());
-        when(aeTitleIdfStreamerMock.get()).thenReturn(Stream.empty());
         when(pubmedsIdfStreamerMock.get()).thenReturn(Stream.empty());
 
 

--- a/base/src/test/java/uk/ac/ebi/atlas/experimentimport/condensedSdrf/IdfParserTest.java
+++ b/base/src/test/java/uk/ac/ebi/atlas/experimentimport/condensedSdrf/IdfParserTest.java
@@ -35,6 +35,13 @@ public class IdfParserTest {
             {"PubMed ID", E_MTAB_513_PUBMED_IDS_ARRAY[0], E_MTAB_513_PUBMED_IDS_ARRAY[1], E_MTAB_513_PUBMED_IDS_ARRAY[2]}
     };
 
+    private static final String[][] E_MTAB_513_IDF_TXT_MIXED_CASE = {
+            {"INVESTIGATION TITLE   ", E_MTAB_513_TITLE},
+            {" comment[AEExperimentDisplayName]", E_MTAB_513_AE_DISPLAY_NAME},
+            {"PubMed id", E_MTAB_513_PUBMED_IDS_ARRAY[0], E_MTAB_513_PUBMED_IDS_ARRAY[1], E_MTAB_513_PUBMED_IDS_ARRAY[2]}
+    };
+
+
     @Mock
     private TsvStreamer titleIdfStreamerMock;
 
@@ -56,6 +63,17 @@ public class IdfParserTest {
     public void parse() {
         when(titleIdfStreamerMock.get()).thenReturn(Stream.of(E_MTAB_513_IDF_TXT));
         when(pubmedsIdfStreamerMock.get()).thenReturn(Stream.of(E_MTAB_513_IDF_TXT));
+
+        Pair<String, ImmutableSet<String>> idfParserOutput = subject.parse(E_MTAB_513);
+
+        assertThat(idfParserOutput.getLeft(), is(E_MTAB_513_AE_DISPLAY_NAME));
+        assertThat(idfParserOutput.getRight(), is(E_MTAB_513_PUBMED_IDS));
+    }
+
+    @Test
+    public void parseMixedCaseKeys() {
+        when(titleIdfStreamerMock.get()).thenReturn(Stream.of(E_MTAB_513_IDF_TXT_MIXED_CASE));
+        when(pubmedsIdfStreamerMock.get()).thenReturn(Stream.of(E_MTAB_513_IDF_TXT_MIXED_CASE));
 
         Pair<String, ImmutableSet<String>> idfParserOutput = subject.parse(E_MTAB_513);
 


### PR DESCRIPTION
* Idf parser retrieves Array Express display name, if that does not exist, it uses the investigation title
* Fixed existing tests
* Added aditional test case