### PR TITLE
Bugfix: gene search example links broken

### DIFF
--- a/sc/src/main/webapp/WEB-INF/jsp/tiles/views/home/search.jsp
+++ b/sc/src/main/webapp/WEB-INF/jsp/tiles/views/home/search.jsp
@@ -12,12 +12,12 @@
         <form method="get" action="${pageContext.request.contextPath}/search" id="home-search-atlas-form">
             <!-- No need to enclose in row as the component already uses Foundation classes -->
             <div id="search"></div>
-            <div class="small-12 columns small padding-bottom-medium">
-                Examples: <a href='${pageContext.request.contextPath}/search?geneQuery=[{"value":"REG1B"}]'>REG1B</a>,
-                <a href='${pageContext.request.contextPath}/search?geneQuery=[{"value":"zinc finger"}]'>zinc finger</a>,
-                <a href='${pageContext.request.contextPath}/search?geneQuery=[{"value":"O14777", "category":"uniprot"}]'>O14777 (UniProt)</a>,
-                <a href='${pageContext.request.contextPath}/search?geneQuery=[{"value":"GO:0010468", "category":"go"}]'>GO:0010468 (regulation of gene expression)</a>
-            </div>
+            <%--<div class="small-12 columns small padding-bottom-medium">--%>
+                <%--Examples: <a href='${pageContext.request.contextPath}/search?geneQuery=[{"value":"REG1B"}]'>REG1B</a>,--%>
+                <%--<a href='${pageContext.request.contextPath}/search?geneQuery=[{"value":"zinc finger"}]'>zinc finger</a>,--%>
+                <%--<a href='${pageContext.request.contextPath}/search?geneQuery=[{"value":"O14777", "category":"uniprot"}]'>O14777 (UniProt)</a>,--%>
+                <%--<a href='${pageContext.request.contextPath}/search?geneQuery=[{"value":"GO:0010468", "category":"go"}]'>GO:0010468 (regulation of gene expression)</a>--%>
+            <%--</div>--%>
 
 
             <div class="row expanded margin-top-large">


### PR DESCRIPTION
I've commented these out for now as we don't have any examples for Single Cell and I don't really want to pick some random gene IDs myself as they will undoubtedly be wrong.

This really needs to be included before we release as the first thing people will do is to click on the example and they will be taken to an error page.