### PR TITLE
Build information endpoint

### DIFF
--- a/gxa/src/main/resources/configuration.properties
+++ b/gxa/src/main/resources/configuration.properties
@@ -38,3 +38,7 @@ go.terms.file = ${data.files.location}/bioentity_properties/go/goIDToTerm.tsv
 
 # uk.ac.ebi.atlas.solr.EmbeddedSolrServerFactory
 solr.location = ${data.files.location}/solr/
+
+buildNumber = ${build.number}
+buildBranch = ${build.branch}
+buildCommitId = ${build.revision}

--- a/sc/src/main/java/uk/ac/ebi/atlas/monitoring/BuildVersionController.java
+++ b/sc/src/main/java/uk/ac/ebi/atlas/monitoring/BuildVersionController.java
@@ -1,0 +1,46 @@
+package uk.ac.ebi.atlas.monitoring;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+import uk.ac.ebi.atlas.controllers.JsonExceptionHandlingController;
+
+import javax.inject.Inject;
+import java.util.HashMap;
+import java.util.Map;
+
+import static uk.ac.ebi.atlas.utils.GsonProvider.GSON;
+
+@RestController
+public class BuildVersionController extends JsonExceptionHandlingController {
+
+    private String buildNumber;
+    private String buildBranch;
+    private String buildCommitId;
+
+    @Inject
+    public BuildVersionController(@Value("#{configuration['buildNumber']}") String buildNumber,
+                                  @Value("#{configuration['buildBranch']}") String buildBranch,
+                                  @Value("#{configuration['buildCommitId']}") String buildCommitId) {
+        this.buildNumber = buildNumber;
+        this.buildBranch = buildBranch;
+        this.buildCommitId = buildCommitId;
+    }
+
+    @RequestMapping(
+            value = "/json/build",
+            method = RequestMethod.GET,
+            produces = MediaType.APPLICATION_JSON_UTF8_VALUE
+    )
+    public String getBuildNumber() {
+        Map<String, String> buildInformation = new HashMap<>();
+
+        buildInformation.put("Bamboo build version", buildNumber);
+        buildInformation.put("Git branch", buildBranch);
+        buildInformation.put("Git commit ID", buildCommitId);
+
+        return GSON.toJson(buildInformation);
+    }
+}

--- a/sc/src/main/java/uk/ac/ebi/atlas/monitoring/JsonBuildVersionController.java
+++ b/sc/src/main/java/uk/ac/ebi/atlas/monitoring/JsonBuildVersionController.java
@@ -1,5 +1,6 @@
 package uk.ac.ebi.atlas.monitoring;
 
+import com.google.common.collect.ImmutableMap;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -8,22 +9,20 @@ import org.springframework.web.bind.annotation.RestController;
 import uk.ac.ebi.atlas.controllers.JsonExceptionHandlingController;
 
 import javax.inject.Inject;
-import java.util.HashMap;
-import java.util.Map;
 
 import static uk.ac.ebi.atlas.utils.GsonProvider.GSON;
 
 @RestController
-public class BuildVersionController extends JsonExceptionHandlingController {
+public class JsonBuildVersionController extends JsonExceptionHandlingController {
 
     private String buildNumber;
     private String buildBranch;
     private String buildCommitId;
 
     @Inject
-    public BuildVersionController(@Value("#{configuration['buildNumber']}") String buildNumber,
-                                  @Value("#{configuration['buildBranch']}") String buildBranch,
-                                  @Value("#{configuration['buildCommitId']}") String buildCommitId) {
+    public JsonBuildVersionController(@Value("#{configuration['buildNumber']}") String buildNumber,
+                                      @Value("#{configuration['buildBranch']}") String buildBranch,
+                                      @Value("#{configuration['buildCommitId']}") String buildCommitId) {
         this.buildNumber = buildNumber;
         this.buildBranch = buildBranch;
         this.buildCommitId = buildCommitId;
@@ -35,12 +34,10 @@ public class BuildVersionController extends JsonExceptionHandlingController {
             produces = MediaType.APPLICATION_JSON_UTF8_VALUE
     )
     public String getBuildNumber() {
-        Map<String, String> buildInformation = new HashMap<>();
-
-        buildInformation.put("Bamboo build version", buildNumber);
-        buildInformation.put("Git branch", buildBranch);
-        buildInformation.put("Git commit ID", buildCommitId);
-
-        return GSON.toJson(buildInformation);
+        return GSON.toJson(
+                ImmutableMap.of(
+                        "bambooBuildVersion", buildNumber,
+                        "gitBranch", buildBranch,
+                        "gitCommitID", buildCommitId));
     }
 }

--- a/sc/src/main/resources/configuration.properties
+++ b/sc/src/main/resources/configuration.properties
@@ -13,3 +13,7 @@ bioentity.properties = ${data.files.location}/bioentity_properties/
 interpro.terms.file = ${data.files.location}/bioentity_properties/interpro/interproIDToTypeTerm.tsv
 # uk.ac.ebi.atlas.bioentity.go.GoPoTermTrader
 go.terms.file = ${data.files.location}/bioentity_properties/go/goIDToTerm.tsv
+
+buildNumber = ${build.number}
+buildBranch = ${build.branch}
+buildCommitId = ${build.revision}

--- a/sc/src/test/java/uk/ac/ebi/atlas/monitoring/JsonBuildVersionControllerWIT.java
+++ b/sc/src/test/java/uk/ac/ebi/atlas/monitoring/JsonBuildVersionControllerWIT.java
@@ -1,0 +1,46 @@
+package uk.ac.ebi.atlas.monitoring;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.hamcrest.Matchers.isA;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(SpringExtension.class)
+@WebAppConfiguration
+@ContextConfiguration(locations = {"classpath:applicationContext.xml", "classpath:dispatcher-servlet.xml"})
+public class JsonBuildVersionControllerWIT {
+
+    @Autowired
+    private WebApplicationContext wac;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    public void setUp() {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
+    }
+
+    @Test
+    public void requestReturnsBuildInfo() throws Exception {
+        mockMvc.perform(get("/json/build"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
+                .andExpect(jsonPath("$.bambooBuildVersion", isA(String.class)))
+                .andExpect(jsonPath("$.gitBranch", isA(String.class)))
+                .andExpect(jsonPath("$.gitCommitID", isA(String.class)))
+        ;
+    }
+}


### PR DESCRIPTION
Added `/json/build` endpoint to expose build information such as:
- Bamboo build number
- Git branch of the build
- Git commit ID of the build

The build information is passed from Bamboo as part of the `mvn package` command:
`-Dbuild.number=${bamboo.buildNumber} -Dbuild.branch=${bamboo.planRepository.branch} -Dbuild.revision=${bamboo.planRepository.revision}`

Open to suggestions for a better URL for the endpoint, not sure if `/build` is the most informative.

