### PR TITLE
Feature #157944301 - Add health check endpoint for Nagios

### DIFF
--- a/base/src/main/java/uk/ac/ebi/atlas/solr/cloud/admin/SolrCloudAdminProxy.java
+++ b/base/src/main/java/uk/ac/ebi/atlas/solr/cloud/admin/SolrCloudAdminProxy.java
@@ -1,0 +1,49 @@
+package uk.ac.ebi.atlas.solr.cloud.admin;
+
+import org.apache.solr.client.solrj.SolrRequest;
+import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.impl.CloudSolrClient;
+import org.apache.solr.client.solrj.request.CollectionAdminRequest;
+import org.apache.solr.common.util.NamedList;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Component
+public class SolrCloudAdminProxy {
+    private final CloudSolrClient cloudSolrClient;
+
+    public SolrCloudAdminProxy(@Qualifier("zkHost") String zkHost) {
+        cloudSolrClient = new CloudSolrClient.Builder().withZkHost(zkHost).build();
+    }
+
+    // TODO should implement a method that checks multiple collections at the same time
+    public boolean isCollectionUp(String collectionName, boolean isAlias) throws IOException, SolrServerException {
+        SolrRequest request = new CollectionAdminRequest.ClusterStatus();
+
+        final NamedList<Object> response = cloudSolrClient.request(request);
+
+        if(isAlias) {
+            collectionName = getCollectionNameForAlias(response, collectionName);
+        }
+
+        LinkedHashMap collectionStatus = (LinkedHashMap) response.findRecursive("cluster", "collections", collectionName);
+
+        Stream<String> collectionShardStates = ((LinkedHashMap) collectionStatus.get("shards")).values().stream().map(x -> ((LinkedHashMap) x).get("state"));
+
+        List<String> statuses = collectionShardStates.filter(x -> !x.equalsIgnoreCase("active")).collect(Collectors.toList());
+
+        return statuses.isEmpty();
+    }
+
+    private String getCollectionNameForAlias(NamedList<Object> queryResponse, String alias) {
+        LinkedHashMap aliases = (LinkedHashMap) queryResponse.findRecursive("cluster", "aliases");
+
+        return aliases.get(alias).toString();
+    }
+}

--- a/base/src/main/java/uk/ac/ebi/atlas/solr/cloud/admin/SolrCloudAdminProxy.java
+++ b/base/src/main/java/uk/ac/ebi/atlas/solr/cloud/admin/SolrCloudAdminProxy.java
@@ -14,7 +14,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 

--- a/base/src/main/java/uk/ac/ebi/atlas/solr/cloud/admin/SolrCloudAdminProxy.java
+++ b/base/src/main/java/uk/ac/ebi/atlas/solr/cloud/admin/SolrCloudAdminProxy.java
@@ -49,7 +49,7 @@ public class SolrCloudAdminProxy {
     private String getCollectionNameForAlias(NamedList<Object> response, String alias) {
         LinkedHashMap aliases = (LinkedHashMap) response.findRecursive("cluster", "aliases");
 
-        Object collectionName = aliases.getOrDefault(alias, null);
+        Object collectionName = aliases.get(alias);
 
         if(collectionName != null) {
             return collectionName.toString();

--- a/base/src/test/java/uk/ac/ebi/atlas/solr/cloud/admin/SolrCloudAdminProxyIT.java
+++ b/base/src/test/java/uk/ac/ebi/atlas/solr/cloud/admin/SolrCloudAdminProxyIT.java
@@ -1,0 +1,43 @@
+package uk.ac.ebi.atlas.solr.cloud.admin;
+
+import org.apache.solr.client.solrj.SolrServerException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration("classpath:applicationContext.xml")
+public class SolrCloudAdminProxyIT {
+
+    @Inject
+    private SolrCloudAdminProxy subject;
+
+    @Test
+    public void validCollectionNamesWithoutAliases() throws IOException, SolrServerException {
+        assertThat(subject.areCollectionsUp(Arrays.asList("bioentities", "analytics"))).isTrue();
+    }
+
+    @Test
+    public void validCollectionNamesWithAliases() throws IOException, SolrServerException {
+        assertThat(subject.areCollectionsUp(Arrays.asList("bioentities", "analytics"), "scxa-analytics")).isTrue();
+    }
+
+    @Test
+    public void invalidCollectionName() {
+        assertThrows(RuntimeException.class, () -> subject.areCollectionsUp(Collections.singletonList("foo")));
+    }
+
+    @Test
+    public void invalidAlias() {
+        assertThrows(RuntimeException.class, () -> subject.areCollectionsUp(Collections.singletonList("bioentities"), "foo"));
+    }
+}

--- a/base/src/test/java/uk/ac/ebi/atlas/solr/cloud/admin/SolrCloudAdminProxyIT.java
+++ b/base/src/test/java/uk/ac/ebi/atlas/solr/cloud/admin/SolrCloudAdminProxyIT.java
@@ -12,7 +12,7 @@ import java.util.Arrays;
 import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration("classpath:applicationContext.xml")
@@ -33,11 +33,11 @@ public class SolrCloudAdminProxyIT {
 
     @Test
     public void invalidCollectionName() {
-        assertThrows(RuntimeException.class, () -> subject.areCollectionsUp(Collections.singletonList("foo")));
+        assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> subject.areCollectionsUp(Collections.singletonList("foo")));
     }
 
     @Test
     public void invalidAlias() {
-        assertThrows(RuntimeException.class, () -> subject.areCollectionsUp(Collections.singletonList("bioentities"), "foo"));
+        assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> subject.areCollectionsUp(Collections.singletonList("bioentities"), "foo"));
     }
 }

--- a/gxa/src/test/java/uk/ac/ebi/atlas/utils/DBSolrStatusControllerIT.java
+++ b/gxa/src/test/java/uk/ac/ebi/atlas/utils/DBSolrStatusControllerIT.java
@@ -24,7 +24,7 @@ public class DBSolrStatusControllerIT {
     private DBSolrStatusController subject;
 
     @Test
-    public void dbAndSolrStatus() throws Exception {
+    public void dbAndSolrStatus() {
         String message = subject.dbAndSolrStatus();
         Map<String, Object> status = GSON.fromJson(message, new TypeToken<Map<String, String>>(){}.getType());
         // Or the unsafer(?) Map status = new Gson().fromJson(message, Map.class);

--- a/sc/src/main/java/uk/ac/ebi/atlas/monitoring/HealthCheckController.java
+++ b/sc/src/main/java/uk/ac/ebi/atlas/monitoring/HealthCheckController.java
@@ -1,0 +1,37 @@
+package uk.ac.ebi.atlas.monitoring;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.solr.client.solrj.SolrServerException;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+import uk.ac.ebi.atlas.solr.cloud.admin.SolrCloudAdminProxy;
+
+import javax.inject.Inject;
+import java.io.IOException;
+
+import static uk.ac.ebi.atlas.utils.GsonProvider.GSON;
+
+@RestController
+public class HealthCheckController {
+    private SolrCloudAdminProxy solrCloudAdminProxy;
+
+    @Inject
+    public HealthCheckController(SolrCloudAdminProxy solrCloudAdminProxy) throws IOException, SolrServerException {
+        this.solrCloudAdminProxy = solrCloudAdminProxy;
+    }
+
+    @RequestMapping(
+            value = "/json/health",
+            method = RequestMethod.GET,
+            produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    public String getHealthStatus() throws IOException, SolrServerException {
+        boolean solrStatus = solrCloudAdminProxy.isCollectionUp("bioentities", false) && solrCloudAdminProxy.isCollectionUp("scxa-analytics", true);
+
+        return GSON.toJson(ImmutableMap.of(
+                "solr", solrStatus ? "UP" : "DOWN"
+        ));
+    }
+
+}

--- a/sc/src/main/java/uk/ac/ebi/atlas/monitoring/HealthCheckController.java
+++ b/sc/src/main/java/uk/ac/ebi/atlas/monitoring/HealthCheckController.java
@@ -1,36 +1,33 @@
 package uk.ac.ebi.atlas.monitoring;
 
 import com.google.common.collect.ImmutableMap;
-import org.apache.solr.client.solrj.SolrServerException;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
-import uk.ac.ebi.atlas.solr.cloud.admin.SolrCloudAdminProxy;
 
 import javax.inject.Inject;
-import java.io.IOException;
 
 import static uk.ac.ebi.atlas.utils.GsonProvider.GSON;
 
 @RestController
 public class HealthCheckController {
-    private SolrCloudAdminProxy solrCloudAdminProxy;
+    private HealthCheckService healthCheckService;
 
     @Inject
-    public HealthCheckController(SolrCloudAdminProxy solrCloudAdminProxy) throws IOException, SolrServerException {
-        this.solrCloudAdminProxy = solrCloudAdminProxy;
+    public HealthCheckController(HealthCheckService healthCheckService) {
+        this.healthCheckService = healthCheckService;
     }
 
     @RequestMapping(
             value = "/json/health",
             method = RequestMethod.GET,
             produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
-    public String getHealthStatus() throws IOException, SolrServerException {
-        boolean solrStatus = solrCloudAdminProxy.isCollectionUp("bioentities", false) && solrCloudAdminProxy.isCollectionUp("scxa-analytics", true);
+    public String getHealthStatus() {
 
         return GSON.toJson(ImmutableMap.of(
-                "solr", solrStatus ? "UP" : "DOWN"
+                "solr", healthCheckService.isSolrUp() ? "UP" : "DOWN",
+                "db", healthCheckService.isDatabaseUp() ? "UP" : "DOWN"
         ));
     }
 

--- a/sc/src/main/java/uk/ac/ebi/atlas/monitoring/HealthCheckService.java
+++ b/sc/src/main/java/uk/ac/ebi/atlas/monitoring/HealthCheckService.java
@@ -30,6 +30,11 @@ public class HealthCheckService {
     }
 
     public boolean isDatabaseUp() {
-        return experimentDao.countExperiments() > 0;
+        try {
+            return experimentDao.countExperiments() > 0;
+        } catch (Exception e) {
+            LOGGER.error(e.getMessage());
+            return false;
+        }
     }
 }

--- a/sc/src/main/java/uk/ac/ebi/atlas/monitoring/HealthCheckService.java
+++ b/sc/src/main/java/uk/ac/ebi/atlas/monitoring/HealthCheckService.java
@@ -1,0 +1,35 @@
+package uk.ac.ebi.atlas.monitoring;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import uk.ac.ebi.atlas.experimentimport.ScxaExperimentDao;
+import uk.ac.ebi.atlas.solr.cloud.admin.SolrCloudAdminProxy;
+
+import java.util.Collections;
+
+@Component
+public class HealthCheckService {
+    private SolrCloudAdminProxy solrCloudAdminProxy;
+    private ScxaExperimentDao experimentDao;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(HealthCheckService.class);
+
+    public HealthCheckService(SolrCloudAdminProxy solrCloudAdminProxy, ScxaExperimentDao experimentDao) {
+        this.solrCloudAdminProxy = solrCloudAdminProxy;
+        this.experimentDao = experimentDao;
+    }
+
+    public boolean isSolrUp() {
+        try {
+            return solrCloudAdminProxy.areCollectionsUp(Collections.singletonList("bioentities"),"scxa-analytics");
+        } catch (Exception e) {
+            LOGGER.error(e.getMessage());
+            return false;
+        }
+    }
+
+    public boolean isDatabaseUp() {
+        return experimentDao.countExperiments() > 0;
+    }
+}

--- a/sc/src/test/java/uk/ac/ebi/atlas/download/ExperimentFileTypeTest.java
+++ b/sc/src/test/java/uk/ac/ebi/atlas/download/ExperimentFileTypeTest.java
@@ -1,48 +1,48 @@
 package uk.ac.ebi.atlas.download;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.ac.ebi.atlas.controllers.ResourceNotFoundException;
 
-import java.util.Arrays;
-import java.util.Collection;
+import java.util.stream.Stream;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-@RunWith(Parameterized.class)
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration("classpath:applicationContext.xml")
 public class ExperimentFileTypeTest {
 
-    @Parameterized.Parameter
-    public String fileTypeId;
-
-    @Parameterized.Parameter(1)
-    public ExperimentFileType fileType;
-
-    @Parameterized.Parameters
-    public static Collection<Object[]> data() {
-        return Arrays.asList(new Object[][] {
-                { "experiment-design", ExperimentFileType.EXPERIMENT_DESIGN },
-                { "sdrf", ExperimentFileType.SDRF },
-                { "cluster", ExperimentFileType.CLUSTERING },
-                { "quantification-raw", ExperimentFileType.QUANTIFICATION_RAW },
-                { "quantification-filtered", ExperimentFileType.QUANTIFICATION_FILTERED }
-        });
+    @ParameterizedTest
+    @MethodSource("stringAndExperimentFileTypeProvider")
+    public void fileTypeFromValidId(String fileTypeId, ExperimentFileType fileType) {
+        assertThat(ExperimentFileType.fromId(fileTypeId)).isEqualByComparingTo(fileType);
     }
 
     @Test
-    public void fileTypeFromValidId() {
-        assertThat(ExperimentFileType.fromId(fileTypeId), is(fileType));
-    }
-
-    @Test(expected = ResourceNotFoundException.class)
     public void fileTypeFromEmptyIdThrowsException() {
-        ExperimentFileType.fromId("");
+        assertThatExceptionOfType(ResourceNotFoundException.class).isThrownBy(() -> ExperimentFileType.fromId(""));
+
     }
 
-    @Test(expected = ResourceNotFoundException.class)
+    @Test
     public void fileTypeFromNonexistentIdThrowsException() {
-        ExperimentFileType.fromId("foo-bar");
+        assertThatExceptionOfType(ResourceNotFoundException.class).isThrownBy(() -> ExperimentFileType.fromId("foo-bar"));
+
+    }
+
+    private static Stream<Arguments> stringAndExperimentFileTypeProvider() {
+        return Stream.of(
+                Arguments.of("experiment-design", ExperimentFileType.EXPERIMENT_DESIGN),
+                Arguments.of("sdrf", ExperimentFileType.SDRF),
+                Arguments.of("cluster", ExperimentFileType.CLUSTERING),
+                Arguments.of("quantification-raw", ExperimentFileType.QUANTIFICATION_RAW),
+                Arguments.of("quantification-filtered", ExperimentFileType.QUANTIFICATION_FILTERED)
+        );
     }
 }

--- a/sc/src/test/java/uk/ac/ebi/atlas/download/FileDownloadControllerWIT.java
+++ b/sc/src/test/java/uk/ac/ebi/atlas/download/FileDownloadControllerWIT.java
@@ -1,29 +1,27 @@
 package uk.ac.ebi.atlas.download;
 
 import com.google.common.net.HttpHeaders;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 import java.text.MessageFormat;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @WebAppConfiguration
 @ContextConfiguration(locations = {"classpath:applicationContext.xml", "classpath:dispatcher-servlet.xml"})
 public class FileDownloadControllerWIT {
@@ -39,7 +37,7 @@ public class FileDownloadControllerWIT {
 
     MockMvc mockMvc;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         this.mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
     }

--- a/sc/src/test/java/uk/ac/ebi/atlas/experimentpage/ExperimentPageContentServiceIT.java
+++ b/sc/src/test/java/uk/ac/ebi/atlas/experimentpage/ExperimentPageContentServiceIT.java
@@ -5,23 +5,23 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.web.WebAppConfiguration;
 import uk.ac.ebi.atlas.download.ExperimentFileLocationService;
 import uk.ac.ebi.atlas.resource.DataFileHub;
-import uk.ac.ebi.atlas.utils.EuropePmcClient;
 import uk.ac.ebi.atlas.testutils.JdbcUtils;
+import uk.ac.ebi.atlas.utils.EuropePmcClient;
 
 import javax.inject.Inject;
 
 import static java.util.stream.Collectors.toSet;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @WebAppConfiguration
 @ContextConfiguration(locations = {"classpath:applicationContext.xml", "classpath:dispatcher-servlet.xml"})
 public class ExperimentPageContentServiceIT {
@@ -42,7 +42,7 @@ public class ExperimentPageContentServiceIT {
 
     private ExperimentPageContentService subject;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         this.subject = new ExperimentPageContentService(experimentFileLocationService, dataFileHub, tsnePlotSettingsService, europePmcClient);
     }

--- a/sc/src/test/java/uk/ac/ebi/atlas/experimentpage/TsnePlotSettingsServiceIT.java
+++ b/sc/src/test/java/uk/ac/ebi/atlas/experimentpage/TsnePlotSettingsServiceIT.java
@@ -1,10 +1,11 @@
 package uk.ac.ebi.atlas.experimentpage;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.web.WebAppConfiguration;
 import uk.ac.ebi.atlas.experimentimport.idf.IdfParser;
 import uk.ac.ebi.atlas.resource.DataFileHub;
@@ -15,8 +16,9 @@ import java.io.UncheckedIOException;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @WebAppConfiguration
 @ContextConfiguration(locations = {"classpath:applicationContext.xml", "classpath:dispatcher-servlet.xml"})
 public class TsnePlotSettingsServiceIT {
@@ -31,7 +33,7 @@ public class TsnePlotSettingsServiceIT {
 
     private TsnePlotSettingsService subject;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         this.subject = new TsnePlotSettingsService(dataFileHub, idfParser);
     }
@@ -46,9 +48,9 @@ public class TsnePlotSettingsServiceIT {
                 .doesNotHaveDuplicates();
     }
 
-    @Test(expected = UncheckedIOException.class)
+    @Test()
     public void getClustersForInvalidAccessionThrowsException() {
-        subject.getAvailableClusters("FOO");
+        assertThatExceptionOfType(UncheckedIOException.class).isThrownBy(() -> subject.getAvailableClusters("FOO"));
     }
 
     @Test

--- a/sc/src/test/java/uk/ac/ebi/atlas/experimentpage/TsnePlotSettingsServiceTest.java
+++ b/sc/src/test/java/uk/ac/ebi/atlas/experimentpage/TsnePlotSettingsServiceTest.java
@@ -1,11 +1,11 @@
 package uk.ac.ebi.atlas.experimentpage;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.ac.ebi.atlas.experimentimport.idf.IdfParser;
 import uk.ac.ebi.atlas.experimentimport.idf.IdfParserOutput;
 import uk.ac.ebi.atlas.testutils.MockDataFileHub;
@@ -16,7 +16,7 @@ import java.util.Collections;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class TsnePlotSettingsServiceTest {
 
     @Mock
@@ -55,7 +55,7 @@ public class TsnePlotSettingsServiceTest {
             {"FALSE", IDF_PREFERRED_K, "xyz111", "xyz222"},
             {"FALSE", "7", "def888", "def999"}};
 
-    @Before
+    @BeforeEach
     public void setUp() {
         dataFileHubMock = MockDataFileHub.create();
         subject = new TsnePlotSettingsService(dataFileHubMock, idfParserMock);

--- a/sc/src/test/java/uk/ac/ebi/atlas/monitoring/HealthCheckControllerWIT.java
+++ b/sc/src/test/java/uk/ac/ebi/atlas/monitoring/HealthCheckControllerWIT.java
@@ -1,0 +1,45 @@
+package uk.ac.ebi.atlas.monitoring;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.oneOf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(SpringExtension.class)
+@WebAppConfiguration
+@ContextConfiguration(locations = {"classpath:applicationContext.xml", "classpath:dispatcher-servlet.xml"})
+public class HealthCheckControllerWIT {
+
+    @Autowired
+    private WebApplicationContext wac;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    public void setUp() {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
+    }
+
+    @Test
+    public void requestReturnsDbAndSolrStatus() throws Exception {
+        mockMvc.perform(get("/json/health"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
+                .andExpect(jsonPath("$.solr", is(oneOf("UP", "DOWN"))))
+                .andExpect(jsonPath("$.db", is(oneOf("UP", "DOWN"))));
+    }
+}

--- a/sc/src/test/java/uk/ac/ebi/atlas/monitoring/HealthCheckServiceTest.java
+++ b/sc/src/test/java/uk/ac/ebi/atlas/monitoring/HealthCheckServiceTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.dao.DataAccessException;
 import uk.ac.ebi.atlas.experimentimport.ScxaExperimentDao;
 import uk.ac.ebi.atlas.solr.cloud.admin.SolrCloudAdminProxy;
 
@@ -51,5 +52,18 @@ public class HealthCheckServiceTest {
         when(solrCloudAdminProxyMock.areCollectionsUp(anyList(), any())).thenThrow(RuntimeException.class);
 
         assertThat(subject.isSolrUp()).isFalse();
+    }
+
+    @Test
+    public void experimentsDatabaseIsUp() {
+        when(experimentDaoMock.countExperiments()).thenReturn(9);
+
+        assertThat(subject.isDatabaseUp()).isTrue();
+    }
+    @Test
+    public void noExperimentsInDatabase() {
+        when(experimentDaoMock.countExperiments()).thenReturn(0);
+
+        assertThat(subject.isDatabaseUp()).isFalse();
     }
 }

--- a/sc/src/test/java/uk/ac/ebi/atlas/monitoring/HealthCheckServiceTest.java
+++ b/sc/src/test/java/uk/ac/ebi/atlas/monitoring/HealthCheckServiceTest.java
@@ -1,11 +1,11 @@
 package uk.ac.ebi.atlas.monitoring;
 
 import org.apache.solr.client.solrj.SolrServerException;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.ac.ebi.atlas.experimentimport.ScxaExperimentDao;
 import uk.ac.ebi.atlas.solr.cloud.admin.SolrCloudAdminProxy;
 
@@ -16,7 +16,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class HealthCheckServiceTest {
 
     @Mock
@@ -27,7 +27,7 @@ public class HealthCheckServiceTest {
 
     private HealthCheckService subject;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         subject = new HealthCheckService(solrCloudAdminProxyMock, experimentDaoMock);
     }

--- a/sc/src/test/java/uk/ac/ebi/atlas/monitoring/HealthCheckServiceTest.java
+++ b/sc/src/test/java/uk/ac/ebi/atlas/monitoring/HealthCheckServiceTest.java
@@ -1,0 +1,55 @@
+package uk.ac.ebi.atlas.monitoring;
+
+import org.apache.solr.client.solrj.SolrServerException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.ac.ebi.atlas.experimentimport.ScxaExperimentDao;
+import uk.ac.ebi.atlas.solr.cloud.admin.SolrCloudAdminProxy;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class HealthCheckServiceTest {
+
+    @Mock
+    private SolrCloudAdminProxy solrCloudAdminProxyMock;
+
+    @Mock
+    private ScxaExperimentDao experimentDaoMock;
+
+    private HealthCheckService subject;
+
+    @Before
+    public void setUp() {
+        subject = new HealthCheckService(solrCloudAdminProxyMock, experimentDaoMock);
+    }
+
+    @Test
+    public void solrCollectionsAreUp() throws IOException, SolrServerException {
+        when(solrCloudAdminProxyMock.areCollectionsUp(anyList(), any())).thenReturn(true);
+
+        assertThat(subject.isSolrUp()).isTrue();
+    }
+
+    @Test
+    public void solrCollectionsAreDown() throws IOException, SolrServerException {
+        when(solrCloudAdminProxyMock.areCollectionsUp(anyList(), any())).thenReturn(false);
+
+        assertThat(subject.isSolrUp()).isFalse();
+    }
+
+    @Test
+    public void solrThrowsException() throws IOException, SolrServerException {
+        when(solrCloudAdminProxyMock.areCollectionsUp(anyList(), any())).thenThrow(RuntimeException.class);
+
+        assertThat(subject.isSolrUp()).isFalse();
+    }
+}

--- a/sc/src/test/java/uk/ac/ebi/atlas/monitoring/HealthCheckServiceTest.java
+++ b/sc/src/test/java/uk/ac/ebi/atlas/monitoring/HealthCheckServiceTest.java
@@ -6,7 +6,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.springframework.dao.DataAccessException;
 import uk.ac.ebi.atlas.experimentimport.ScxaExperimentDao;
 import uk.ac.ebi.atlas.solr.cloud.admin.SolrCloudAdminProxy;
 

--- a/sc/src/test/java/uk/ac/ebi/atlas/search/GeneSearchServiceTest.java
+++ b/sc/src/test/java/uk/ac/ebi/atlas/search/GeneSearchServiceTest.java
@@ -1,11 +1,11 @@
 package uk.ac.ebi.atlas.search;
 
 import com.google.common.collect.ImmutableMap;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.ac.ebi.atlas.solr.cloud.fullanalytics.SingleCellAnalyticsCollectionProxy.SingleCellAnalyticsSchemaField;
 
 import java.util.Arrays;
@@ -19,14 +19,14 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class GeneSearchServiceTest {
     @Mock
     private GeneSearchServiceDao geneSearchServiceDaoMock;
 
     private GeneSearchService subject;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         subject = new GeneSearchService(geneSearchServiceDaoMock);
     }

--- a/sc/src/test/java/uk/ac/ebi/atlas/search/JsonBioentityInformationControllerWIT.java
+++ b/sc/src/test/java/uk/ac/ebi/atlas/search/JsonBioentityInformationControllerWIT.java
@@ -1,12 +1,12 @@
 package uk.ac.ebi.atlas.search;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -24,7 +24,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @WebAppConfiguration
 @ContextConfiguration(locations = {"classpath:applicationContext.xml", "classpath:dispatcher-servlet.xml"})
 public class JsonBioentityInformationControllerWIT {
@@ -36,7 +36,7 @@ public class JsonBioentityInformationControllerWIT {
 
     private MockMvc mockMvc;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         this.mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
     }


### PR DESCRIPTION
- Implemented new `/json/health` endpoint that indicates whether Solr and the database are up or down
- Implemented `SolrCloudAdminProxy` to handle status check requests via the Solr Admin API (this is not a very generic class at the moment and the name could probably be changed)
- Tests!