### PR TITLE
Bugfix #159432631 - Experiments with no publication IDs can show wrong paper

### DIFF
--- a/base/src/main/java/uk/ac/ebi/atlas/experimentimport/idf/IdfParserOutput.java
+++ b/base/src/main/java/uk/ac/ebi/atlas/experimentimport/idf/IdfParserOutput.java
@@ -3,6 +3,7 @@ package uk.ac.ebi.atlas.experimentimport.idf;
 import uk.ac.ebi.atlas.model.Publication;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -43,7 +44,10 @@ public class IdfParserOutput {
     }
 
     public Set<String> getPubmedIds() {
-        return publications.stream().map(Publication::getPubmedId).collect(Collectors.toSet());
+        return publications.stream()
+                .map(Publication::getPubmedId)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
     }
 
     public List<String> getMetadataFieldsOfInterest() {
@@ -51,6 +55,10 @@ public class IdfParserOutput {
     }
 
     public Set<String> getDois() {
-        return publications.stream().map(Publication::getDoi).collect(Collectors.toSet());
+        return publications
+                .stream()
+                .map(Publication::getDoi)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
     }
 }

--- a/base/src/test/java/uk/ac/ebi/atlas/experimentimport/idf/IdfParserOutputTest.java
+++ b/base/src/test/java/uk/ac/ebi/atlas/experimentimport/idf/IdfParserOutputTest.java
@@ -1,0 +1,56 @@
+package uk.ac.ebi.atlas.experimentimport.idf;
+
+import org.junit.jupiter.api.Test;
+import uk.ac.ebi.atlas.model.Publication;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class IdfParserOutputTest {
+
+    private IdfParserOutput subject;
+
+    private static final List<Publication> publicationsWithNulls = Arrays.asList(
+            new Publication(null, null, "Title 1"),
+            new Publication("123", "0/0.1", "Title 2"),
+            new Publication("456", "1.1/abc", "Title 3"));
+
+    private static final List<Publication> publicationsWithoutNulls = Arrays.asList(
+            new Publication("111", "1/1.aaa", "Title 1"),
+            new Publication("123", "0/0.1", "Title 2"),
+            new Publication("456", "1.1/abc", "Title 3"));
+
+    @Test
+    void testGetters() {
+        subject = new IdfParserOutput(
+                "Another experiment title",
+                "Another experiment description",
+                publicationsWithoutNulls,
+                3,
+                Arrays.asList("field1", "field2"));
+
+        assertThat(subject.getTitle()).isEqualTo("Another experiment title");
+        assertThat(subject.getExperimentDescription()).isEqualTo("Another experiment description");
+        assertThat(subject.getExpectedClusters()).isEqualTo(3);
+        assertThat(subject.getMetadataFieldsOfInterest()).containsExactly("field1", "field2");
+        assertThat(subject.getPublications()).containsExactlyElementsOf(publicationsWithoutNulls);
+        assertThat(subject.getPubmedIds()).containsOnly("111", "123", "456");
+        assertThat(subject.getDois()).containsOnly("1/1.aaa", "0/0.1", "1.1/abc");
+    }
+
+    @Test
+    void testDoisAndPubmedIdsWithNulls() {
+        subject = new IdfParserOutput(
+                "Experiment title",
+                "Experiment description",
+                publicationsWithNulls,
+                0,
+                Collections.singletonList("field1"));
+
+        assertThat(subject.getPubmedIds()).containsOnly("123", "456");
+        assertThat(subject.getDois()).containsOnly("0/0.1", "1.1/abc");
+    }
+}

--- a/sc/src/main/java/uk/ac/ebi/atlas/experimentimport/ScxaExperimentDao.java
+++ b/sc/src/main/java/uk/ac/ebi/atlas/experimentimport/ScxaExperimentDao.java
@@ -7,8 +7,10 @@ import uk.ac.ebi.atlas.model.experiment.ExperimentType;
 
 import javax.inject.Inject;
 import javax.inject.Named;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -47,8 +49,8 @@ public class ScxaExperimentDao extends ExperimentDao {
                 experimentDto.getSpecies(),
                 experimentDto.isPrivate(),
                 accessKeyUuid.toString(),
-                experimentDto.getPubmedIds().stream().collect(Collectors.joining(", ")),
-                experimentDto.getDois().stream().collect(Collectors.joining(", ")),
+                getPublicationIdsAsString(experimentDto.getPubmedIds()),
+                getPublicationIdsAsString(experimentDto.getDois()),
                 experimentDto.getTitle());
     }
 
@@ -103,5 +105,13 @@ public class ScxaExperimentDao extends ExperimentDao {
     private ExperimentDTO getSingleExperiment(List<ExperimentDTO> experimentDtos, String accession) {
         checkExperimentFound(experimentDtos.size() == 1, accession);
         return experimentDtos.get(0);
+    }
+
+    // Returns comma-separated IDs, or null if there are no IDs
+    private String getPublicationIdsAsString(Collection<String> publicationIds) {
+        return publicationIds.stream()
+                .collect(Collectors.collectingAndThen(
+                        Collectors.joining(", "),
+                        (result) -> result.isEmpty() ? null : result));
     }
 }

--- a/sc/src/main/java/uk/ac/ebi/atlas/experimentimport/ScxaExperimentDtoResultSetExtractor.java
+++ b/sc/src/main/java/uk/ac/ebi/atlas/experimentimport/ScxaExperimentDtoResultSetExtractor.java
@@ -21,13 +21,15 @@ public class ScxaExperimentDtoResultSetExtractor extends ExperimentDTOResultSetE
         String accessKeyUUID = resultSet.getString("access_key");
         String title = StringUtils.isEmpty(resultSet.getString("title")) ? "" : resultSet.getString("title");
 
-        String pubMedIdsString = resultSet.getString("pubmed_Ids");
-        Set<String> pubMedIds = StringUtils.isBlank(pubMedIdsString) ?
+        String pubMedIdsString = resultSet.getString("pubmed_ids");
+
+        Set<String> pubMedIds = resultSet.wasNull() || StringUtils.isBlank(pubMedIdsString)?
                 new HashSet<>() :
                 Sets.newHashSet(Splitter.on(", ").split(pubMedIdsString));
 
         String doisString = resultSet.getString("dois");
-        Set<String> dois = StringUtils.isBlank(doisString) ?
+
+        Set<String> dois = resultSet.wasNull() || StringUtils.isBlank(doisString) ?
                 new HashSet<>() :
                 Sets.newHashSet(Splitter.on(", ").split(doisString));
 

--- a/sc/src/test/java/uk/ac/ebi/atlas/experimentimport/ScxaExperimentDaoIT.java
+++ b/sc/src/test/java/uk/ac/ebi/atlas/experimentimport/ScxaExperimentDaoIT.java
@@ -37,8 +37,6 @@ public class ScxaExperimentDaoIT {
 
     @Before
     public void setUp() throws Exception {
-        UUID uuid = UUID.randomUUID();
-
         ExperimentDTO experimentDto =
                 new ExperimentDTO(
                         SC_ACCESSION,
@@ -54,7 +52,7 @@ public class ScxaExperimentDaoIT {
     }
 
     @After
-    public void tearDown() throws Exception {
+    public void tearDown() {
         try {
             subject.deleteExperiment(SC_ACCESSION);
         } catch (ResourceNotFoundException e) {

--- a/sc/src/test/java/uk/ac/ebi/atlas/experimentimport/ScxaExperimentDtoResultSetExtractorTest.java
+++ b/sc/src/test/java/uk/ac/ebi/atlas/experimentimport/ScxaExperimentDtoResultSetExtractorTest.java
@@ -1,0 +1,117 @@
+package uk.ac.ebi.atlas.experimentimport;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.ac.ebi.atlas.model.experiment.ExperimentType;
+import uk.ac.ebi.atlas.testutils.RandomDataTestUtils;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class ScxaExperimentDtoResultSetExtractorTest {
+
+    @Mock
+    private ResultSet mockResultSet;
+
+    private Timestamp currentTime;
+    private ScxaExperimentDtoResultSetExtractor subject;
+
+    @BeforeEach
+    public void setUp() {
+        subject = new ScxaExperimentDtoResultSetExtractor();
+        currentTime = new Timestamp(System.currentTimeMillis());
+    }
+
+    @Test
+    void createsValidExperimentDTO() throws SQLException {
+        String experimentAccession = RandomDataTestUtils.getRandomExperimentAccession();
+        createMockResultSet(ExperimentType.SINGLE_CELL_RNASEQ_MRNA_BASELINE,
+                "Homo sapiens",
+                "123",
+                true,
+                currentTime,
+                "This is a dummy title",
+                "123, 124, 125",
+                "10.10/abc, 12.100/abc, 13.9/abc");
+
+        ExperimentDTO result = subject.createExperimentDTO(mockResultSet, experimentAccession);
+
+        assertThat(result.getExperimentAccession()).isEqualToIgnoringCase(experimentAccession);
+        assertThat(result.getExperimentType()).isEqualByComparingTo(ExperimentType.SINGLE_CELL_RNASEQ_MRNA_BASELINE);
+        assertThat(result.getSpecies()).isEqualToIgnoringCase("Homo sapiens");
+        assertThat(result.getAccessKey()).isEqualToIgnoringCase("123");
+        assertThat(result.isPrivate()).isTrue();
+        assertThat(result.getLastUpdate()).hasSameTimeAs(currentTime);
+        assertThat(result.getTitle()).isNotEmpty();
+        assertThat(result.getPubmedIds()).hasSize(3);
+        assertThat(result.getDois()).hasSize(3);
+    }
+
+    @Test
+    void createsExperimentDTOWithEmptyFields() throws SQLException {
+        String experimentAccession = RandomDataTestUtils.getRandomExperimentAccession();
+        createMockResultSet(ExperimentType.SINGLE_CELL_RNASEQ_MRNA_BASELINE,
+                "Homo sapiens",
+                "",
+                false,
+                currentTime,
+                "",
+                "",
+                "");
+
+        ExperimentDTO result = subject.createExperimentDTO(mockResultSet, experimentAccession);
+
+        assertThat(result.getTitle()).isEmpty();
+        assertThat(result.getAccessKey()).isEmpty();
+        assertThat(result.getPubmedIds()).isEmpty();
+        assertThat(result.getDois()).isEmpty();
+    }
+
+    @Test
+    void createsExperimentDTOWithNullFields() throws SQLException {
+        String experimentAccession = RandomDataTestUtils.getRandomExperimentAccession();
+        createMockResultSet(ExperimentType.SINGLE_CELL_RNASEQ_MRNA_BASELINE,
+                "Homo sapiens",
+                "",
+                false,
+                currentTime,
+                "",
+                null,
+                null);
+
+        ExperimentDTO result = subject.createExperimentDTO(mockResultSet, experimentAccession);
+
+        assertThat(result.getPubmedIds()).isEmpty();
+        assertThat(result.getDois()).isEmpty();
+    }
+
+    private void createMockResultSet(ExperimentType experimentType,
+                                     String species,
+                                     String accessKey,
+                                     boolean isPrivate,
+                                     Timestamp lastUpdate,
+                                     String title,
+                                     String pubmedIds,
+                                     String dois) throws SQLException {
+
+        when(mockResultSet.getString("type")).thenReturn(experimentType.name());
+        when(mockResultSet.getString("species")).thenReturn(species);
+        when(mockResultSet.getString("access_key")).thenReturn(accessKey);
+        when(mockResultSet.getBoolean("private")).thenReturn(isPrivate);
+        when(mockResultSet.getTimestamp("last_update")).thenReturn(lastUpdate);
+        when(mockResultSet.getString("title")).thenReturn(title);
+        when(mockResultSet.getString("pubmed_ids")).thenReturn(pubmedIds);
+        when(mockResultSet.getString("dois")).thenReturn(dois);
+    }
+}


### PR DESCRIPTION
Fixes issue where the string "null" was saved as the Pubmed ID/DOI in the database when an experiment has a publication title, but no PubmedID or DOI. This caused a query to EuropePMC for "null", which for some reason produces a paper about ferrets. 