### PR TITLE
Bugfix #159002874 - OpenTargets microarray JSON dump (#128)

### DIFF
--- a/base/src/main/java/uk/ac/ebi/atlas/model/experiment/differential/microarray/MicroarrayProfile.java
+++ b/base/src/main/java/uk/ac/ebi/atlas/model/experiment/differential/microarray/MicroarrayProfile.java
@@ -38,4 +38,7 @@ public class MicroarrayProfile extends DifferentialProfile<MicroarrayExpression,
         return new MicroarrayProfile(getId(), getName(), designElementName);
     }
 
+    public String getDesignElementName() {
+        return designElementName;
+    }
 }

--- a/base/src/test/java/uk/ac/ebi/atlas/experimentimport/analyticsindex/conditions/ConditionsLookupServiceTest.java
+++ b/base/src/test/java/uk/ac/ebi/atlas/experimentimport/analyticsindex/conditions/ConditionsLookupServiceTest.java
@@ -17,7 +17,6 @@ import uk.ac.ebi.atlas.model.AssayGroup;
 import uk.ac.ebi.atlas.model.experiment.ExperimentDesign;
 import uk.ac.ebi.atlas.model.experiment.differential.Contrast;
 import uk.ac.ebi.atlas.model.experiment.differential.ContrastTest;
-import uk.ac.ebi.atlas.model.experiment.differential.DifferentialExperimentTest;
 import uk.ac.ebi.atlas.testutils.MockAssayGroups;
 import uk.ac.ebi.atlas.testutils.MockExperiment;
 
@@ -32,6 +31,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static uk.ac.ebi.atlas.testutils.MockExperiment.createDifferentialExperiment;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ConditionsLookupServiceTest {
@@ -149,7 +149,7 @@ public class ConditionsLookupServiceTest {
         setup.accept(contrast, experimentDesign);
 
         assertThat(
-                new ConditionsLookupService(new EFOLookupService(m)).conditionsPerDataColumnDescriptor(DifferentialExperimentTest.mockExperiment(
+                new ConditionsLookupService(new EFOLookupService(m)).conditionsPerDataColumnDescriptor(createDifferentialExperiment(
                         "accession",
                         contrasts,
                         experimentDesign

--- a/base/src/test/java/uk/ac/ebi/atlas/model/analyticsindex/DifferentialExperimentDataPointTest.java
+++ b/base/src/test/java/uk/ac/ebi/atlas/model/analyticsindex/DifferentialExperimentDataPointTest.java
@@ -3,18 +3,17 @@ package uk.ac.ebi.atlas.model.analyticsindex;
 import com.google.common.collect.ImmutableList;
 import org.junit.Test;
 import uk.ac.ebi.atlas.experimentimport.analytics.differential.rnaseq.RnaSeqDifferentialAnalytics;
-import uk.ac.ebi.atlas.model.experiment.differential.DifferentialExperimentTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static uk.ac.ebi.atlas.testutils.MockExperiment.createDifferentialExperiment;
 
 public class DifferentialExperimentDataPointTest {
 
     @Test
     public void testGetRelevantBioentityPropertyNames() {
         DifferentialExperimentDataPoint subject =
-                new DifferentialExperimentDataPoint(DifferentialExperimentTest.mockExperiment("E-GEOD-54705",
-                                                                                              ImmutableList.of()),
-                                                    new RnaSeqDifferentialAnalytics("","",0.03, 1.23),"",5);
+                new DifferentialExperimentDataPoint(createDifferentialExperiment(
+                        "E-GEOD-54705", ImmutableList.of()), new RnaSeqDifferentialAnalytics("","",0.03, 1.23),"",5);
 
         assertThat(subject.getProperties())
                 .containsKeys("factors", "regulation", "contrast_id", "num_replicates", "fold_change", "p_value")

--- a/base/src/test/java/uk/ac/ebi/atlas/model/experiment/differential/DifferentialExperimentTest.java
+++ b/base/src/test/java/uk/ac/ebi/atlas/model/experiment/differential/DifferentialExperimentTest.java
@@ -1,11 +1,7 @@
 package uk.ac.ebi.atlas.model.experiment.differential;
 
-import com.google.common.base.Function;
-import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Sets;
 import com.google.gson.JsonArray;
-import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -13,16 +9,10 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.ac.ebi.atlas.model.AssayGroup;
 import uk.ac.ebi.atlas.model.experiment.ExperimentDesign;
 import uk.ac.ebi.atlas.model.experiment.ExperimentDesignTest;
-import uk.ac.ebi.atlas.species.Species;
-import uk.ac.ebi.atlas.species.SpeciesProperties;
 
-import java.util.Date;
-import java.util.List;
-import java.util.stream.Stream;
-
-import static java.util.stream.Collectors.toList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static uk.ac.ebi.atlas.testutils.MockExperiment.createDifferentialExperiment;
 import static uk.ac.ebi.atlas.utils.GsonProvider.GSON;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -30,39 +20,19 @@ public class DifferentialExperimentTest {
     private static final String PUBMEDID = "PUBMEDID";
     private static final String DOI = "100.100/doi";
 
+    private AssayGroup referenceAssay1 = new AssayGroup("g1", "assay1");
+    private AssayGroup testAssay1 = new AssayGroup("g2", "assay2");
+    private AssayGroup referenceAssay2 = new AssayGroup("g3", "assay3");
+    private AssayGroup testAssay2 = new AssayGroup("g4", "assay41", "assay42");
+
+    private Contrast c1 = new Contrast("g1_g2", null, referenceAssay1, testAssay1, "first contrast");
+    private Contrast c2 = new Contrast("g3_g4", null, referenceAssay2, testAssay2, "second contrast");
+
     private DifferentialExperiment subject;
-
-    AssayGroup referenceAssay1 = new AssayGroup("g1", "assay1");
-    AssayGroup testAssay1 = new AssayGroup("g2", "assay2");
-    AssayGroup referenceAssay2 = new AssayGroup("g3", "assay3");
-    AssayGroup testAssay2 = new AssayGroup("g4", "assay41", "assay42");
-
-    Contrast c1 = new Contrast("g1_g2", null, referenceAssay1, testAssay1, "first contrast");
-    Contrast c2 = new Contrast("g3_g4", null, referenceAssay2, testAssay2, "second contrast");
-
-    public static DifferentialExperiment mockExperiment(String accession, List<Contrast> contrasts) {
-        return mockExperiment(
-                accession,
-                contrasts,
-                ExperimentDesignTest.mockExperimentDesign(
-                        contrasts.stream()
-                                 .flatMap(contrast ->
-                                          Stream.of(contrast.getTestAssayGroup(), contrast.getReferenceAssayGroup()))
-                                 .collect(toList())));
-    }
-
-    public static DifferentialExperiment mockExperiment(String accession, List<Contrast> contrasts, ExperimentDesign experimentDesign){
-        return new DifferentialExperiment(
-                accession,
-                new Date(),
-                contrasts.stream().map(contrast -> Pair.of(contrast, true)).collect(toList()),
-                "description", new Species("species", SpeciesProperties.UNKNOWN), Sets.newHashSet(PUBMEDID),
-                Sets.newHashSet(DOI), experimentDesign);
-    }
 
     @Before
     public void setUp() throws Exception {
-        subject = mockExperiment("accession",ImmutableList.of(c1, c2));
+        subject = createDifferentialExperiment("accession",ImmutableList.of(c1, c2));
     }
 
     @Test
@@ -83,7 +53,7 @@ public class DifferentialExperimentTest {
 
     @Test
     public void testGetPubMedIds() {
-        assertThat((Iterable<String>) subject.getPubMedIds(), contains(PUBMEDID));
+        assertThat(subject.getPubMedIds(), contains(PUBMEDID));
     }
 
     @Test
@@ -93,7 +63,11 @@ public class DifferentialExperimentTest {
 
     @Test
     public void groupingsForHeatmapIncludeComparisonName() {
-        DifferentialExperiment experiment = mockExperiment("accession", ImmutableList.of(c1), ExperimentDesignTest.mockExperimentDesign(ImmutableList.of(referenceAssay1, testAssay1)));
+        DifferentialExperiment experiment =
+                createDifferentialExperiment(
+                        "accession",
+                        ImmutableList.of(c1),
+                        ExperimentDesignTest.mockExperimentDesign(ImmutableList.of(referenceAssay1, testAssay1)));
         JsonArray result = experiment.groupingsForHeatmap();
 
         assertThat(result.size(), greaterThan(0));
@@ -107,7 +81,8 @@ public class DifferentialExperimentTest {
         experimentDesign.putFactor(referenceAssay1.getFirstAssayAccession(), "infect", "totally_normal");
         experimentDesign.putFactor(testAssay1.getFirstAssayAccession(), "infect", "very_disease");
 
-        DifferentialExperiment experiment = mockExperiment("accession", ImmutableList.of(c1), experimentDesign);
+        DifferentialExperiment experiment =
+                createDifferentialExperiment("accession", ImmutableList.of(c1), experimentDesign);
         JsonArray result = experiment.groupingsForHeatmap();
 
         assertThat(result.size(), is(2));
@@ -116,5 +91,4 @@ public class DifferentialExperimentTest {
 
         assertThat(stringDump.indexOf("very_disease"), lessThan(stringDump.indexOf("totally_normal")));
     }
-
 }

--- a/base/src/test/java/uk/ac/ebi/atlas/profiles/ProfileStreamFilterTest.java
+++ b/base/src/test/java/uk/ac/ebi/atlas/profiles/ProfileStreamFilterTest.java
@@ -15,36 +15,28 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertThat;
+import static uk.ac.ebi.atlas.testutils.MockExperiment.createDifferentialExperiment;
 
 public class ProfileStreamFilterTest {
+    private AssayGroup g1 = new AssayGroup("g1", "assay_1");
+    private AssayGroup g2 = new AssayGroup("g2", "assay_2");
+    private AssayGroup g3 = new AssayGroup("g3", "assay_3");
 
+    private Contrast g1_g2 = new Contrast("g1_g2", null, g1, g2, "contrast 1");
+    private Contrast g1_g3 = new Contrast("g1_g3", null, g1, g3, "contrast 2");
 
-    AssayGroup g1 = new AssayGroup("g1", "assay_1");
-    AssayGroup g2 = new AssayGroup("g2", "assay_2");
-    AssayGroup g3 = new AssayGroup("g3", "assay_3");
+    private DifferentialExperiment experiment = createDifferentialExperiment("accession", ImmutableList.of(g1_g2, g1_g3));
 
-    Contrast g1_g2 = new Contrast("g1_g2", null, g1, g2, "contrast 1");
-    Contrast g1_g3 = new Contrast("g1_g3", null, g1, g3, "contrast 2");
-
-
-
-    DifferentialExperiment experiment = DifferentialExperimentTest.mockExperiment("accession", ImmutableList.of(g1_g2, g1_g3));
-
-
-    RnaSeqProfile profile(DifferentialExpression expressionForG1_G2,
-                          DifferentialExpression expressionForG1_G3) {
+    private RnaSeqProfile profile(DifferentialExpression expressionForG1_G2,
+                                  DifferentialExpression expressionForG1_G3) {
         RnaSeqProfile profile = new RnaSeqProfile("id", "name");
-        Optional.ofNullable(expressionForG1_G2).ifPresent(e ->
-                profile.add(g1_g2, e)
-        );
-        Optional.ofNullable(expressionForG1_G3).ifPresent(e ->
-                profile.add(g1_g3, e)
-        );
+        Optional.ofNullable(expressionForG1_G2).ifPresent(e -> profile.add(g1_g2, e));
+        Optional.ofNullable(expressionForG1_G3).ifPresent(e -> profile.add(g1_g3, e));
         return profile;
     }
 
-    void test(RnaSeqProfile profile, DifferentialRequestPreferences differentialRequestPreferences, boolean expected){
+    private void test(RnaSeqProfile profile, DifferentialRequestPreferences differentialRequestPreferences, boolean expected){
         Predicate f = ProfileStreamFilter.create(new RnaSeqRequestContext(differentialRequestPreferences, experiment));
         assertThat(
                 profile.toString(),
@@ -52,18 +44,16 @@ public class ProfileStreamFilterTest {
                 is(expected)
         );
     }
-    void test(RnaSeqProfile profile, boolean expected){
+
+    private void test(RnaSeqProfile profile, boolean expected){
         test(profile, new DifferentialRequestPreferences(), expected);
     }
 
-
-
-    void test(RnaSeqProfile profile, Collection<Contrast> keepContrasts, boolean expected){
+    private void test(RnaSeqProfile profile, Collection<Contrast> keepContrasts, boolean expected){
         DifferentialRequestPreferences differentialRequestPreferences = new DifferentialRequestPreferences();
         differentialRequestPreferences.setSelectedColumnIds(keepContrasts.stream().map(DescribesDataColumns::getId).collect(Collectors.toSet()));
         test(profile,differentialRequestPreferences , expected);
     }
-
 
     @Test
     public void filterOutEmptyProfiles(){
@@ -82,19 +72,19 @@ public class ProfileStreamFilterTest {
 
     @Test
     public void keepProfileIfExpressedOnSpecifiedColumns(){
-        test(profile(new DifferentialExpression(0.01, 2.0), new DifferentialExpression(0.03, 4.0)),
+        test(profile(
+                new DifferentialExpression(0.01, 2.0), new DifferentialExpression(0.03, 4.0)),
                 ImmutableList.of(g1_g2, g1_g3), true);
-        test(profile(new DifferentialExpression(0.01, 2.0), new DifferentialExpression(0.03, 4.0)),
+        test(profile(
+                new DifferentialExpression(0.01, 2.0), new DifferentialExpression(0.03, 4.0)),
                 ImmutableList.of(g1_g2), true);
-        test(profile(new DifferentialExpression(0.01, 2.0), new DifferentialExpression(0.03, 4.0)),
+        test(profile(
+                new DifferentialExpression(0.01, 2.0), new DifferentialExpression(0.03, 4.0)),
                 ImmutableList.of(g1_g3), true);
 
-        test(profile(new DifferentialExpression(0.01, 2.0), null),
-                ImmutableList.of(g1_g2, g1_g3), true);
-        test(profile(new DifferentialExpression(0.01, 2.0), null),
-                ImmutableList.of(g1_g2), true);
-        test(profile(new DifferentialExpression(0.01, 2.0), null),
-                ImmutableList.of(g1_g3), false);
+        test(profile(new DifferentialExpression(0.01, 2.0), null), ImmutableList.of(g1_g2, g1_g3), true);
+        test(profile(new DifferentialExpression(0.01, 2.0), null), ImmutableList.of(g1_g2), true);
+        test(profile(new DifferentialExpression(0.01, 2.0), null), ImmutableList.of(g1_g3), false);
     }
 
 }

--- a/base/src/test/java/uk/ac/ebi/atlas/profiles/stream/RnaSeqProfileStreamFactoryPickUpExpressionsByIndexTest.java
+++ b/base/src/test/java/uk/ac/ebi/atlas/profiles/stream/RnaSeqProfileStreamFactoryPickUpExpressionsByIndexTest.java
@@ -1,13 +1,11 @@
 package uk.ac.ebi.atlas.profiles.stream;
 
 import com.google.common.collect.ImmutableList;
-import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 import uk.ac.ebi.atlas.model.AssayGroup;
 import uk.ac.ebi.atlas.model.experiment.differential.Contrast;
 import uk.ac.ebi.atlas.model.experiment.differential.DifferentialExperiment;
-import uk.ac.ebi.atlas.model.experiment.differential.DifferentialExperimentTest;
 import uk.ac.ebi.atlas.model.experiment.differential.DifferentialExpression;
 import uk.ac.ebi.atlas.model.experiment.differential.rnaseq.RnaSeqProfile;
 import uk.ac.ebi.atlas.testutils.MockDataFileHub;
@@ -16,64 +14,71 @@ import java.util.function.Function;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+import static uk.ac.ebi.atlas.testutils.MockExperiment.createDifferentialExperiment;
 
 public class RnaSeqProfileStreamFactoryPickUpExpressionsByIndexTest {
+    private static final String id = "id";
+    private static final String name = "name";
+    private static final String P_VAL_1 = "1";
+    private static final String FOLD_CHANGE_1 = "0.474360080385946";
 
+    private static final String P_VAL_2 = "0.5";
+    private static final String FOLD_CHANGE_2 = "0.1337";
 
-    AssayGroup g1 = new AssayGroup("g1", "run_11", "run_12", "run_13");
-    AssayGroup g2 = new AssayGroup("g2", "run_21", "run_22", "run_23", "run_24");
-    AssayGroup g3 = new AssayGroup("g3", "run_31", "run_32");
+    private static final AssayGroup g1 = new AssayGroup("g1", "run_11", "run_12", "run_13");
+    private static final AssayGroup g2 = new AssayGroup("g2", "run_21", "run_22", "run_23", "run_24");
+    private static final AssayGroup g3 = new AssayGroup("g3", "run_31", "run_32");
 
-    Contrast g1_g2 = new Contrast("g1_g2", "", g1, g2, "first contrast");
-    Contrast g1_g3 = new Contrast("g1_g3", "", g1, g3, "second contrast");
+    private static final Contrast g1_g2 = new Contrast("g1_g2", "", g1, g2, "first contrast");
+    private static final Contrast g1_g3 = new Contrast("g1_g3", "", g1, g3, "second contrast");
 
+    private Function<String[], RnaSeqProfile> goThroughTsvLineAndPickUpExpressionsByIndex;
 
-    MockDataFileHub dataFileHub;
-
-    RnaSeqProfileStreamFactory.Impl subject;
-
-    Function<String[], RnaSeqProfile> goThroughTsvLineAndPickUpExpressionsByIndex;
-
-    DifferentialExperiment differentialExperiment = DifferentialExperimentTest.mockExperiment(
+    private DifferentialExperiment differentialExperiment = createDifferentialExperiment(
             "accession", ImmutableList.of(g1_g2, g1_g3)
     );
 
-    String id = "id";
-    String name = "name";
-    String P_VAL_1 = "1";
-    String FOLD_CHANGE_1 = "0.474360080385946";
-
-    String P_VAL_2 = "0.5";
-    String FOLD_CHANGE_2 = "0.1337";
-
     @Before
     public void setUp() throws Exception {
-        dataFileHub = MockDataFileHub.create();
-        subject = new RnaSeqProfileStreamFactory.Impl(dataFileHub);
-        goThroughTsvLineAndPickUpExpressionsByIndex = subject.howToReadLine(differentialExperiment, x -> true).apply(
-                "Gene ID\tGene Name\tg1_g2.p-value\tg1_g2.log2foldchange\tg1_g3.p-value\tg1_g3.log2foldchange".split("\t")
-        );
+        MockDataFileHub dataFileHub = MockDataFileHub.create();
+        RnaSeqProfileStreamFactory.Impl subject = new RnaSeqProfileStreamFactory.Impl(dataFileHub);
+        goThroughTsvLineAndPickUpExpressionsByIndex =
+                subject.howToReadLine(differentialExperiment, x -> true).apply(
+                "Gene ID\tGene Name\tg1_g2.p-value\tg1_g2.log2foldchange\tg1_g3.p-value\tg1_g3.log2foldchange"
+                        .split("\t"));
     }
 
     @Test
     public void parseRightValues() {
-        assertThat(goThroughTsvLineAndPickUpExpressionsByIndex.apply(new String[]{id, name, P_VAL_1, FOLD_CHANGE_1, P_VAL_2, FOLD_CHANGE_2}).getExpression(g1_g3), Matchers.is(
-                new DifferentialExpression(0.5, 0.1337)
-        ));
+        assertThat(
+                goThroughTsvLineAndPickUpExpressionsByIndex.apply(
+                        new String[]{id, name, P_VAL_1, FOLD_CHANGE_1, P_VAL_2, FOLD_CHANGE_2})
+                        .getExpression(g1_g3),
+                is(new DifferentialExpression(0.5, 0.1337)));
     }
 
     @Test
     public void handleInfinity() {
-        assertThat(goThroughTsvLineAndPickUpExpressionsByIndex.apply(new String[]{id, name, P_VAL_1, FOLD_CHANGE_1, P_VAL_2, "-Inf"}).getExpression(g1_g3), Matchers.is(
-                new DifferentialExpression(0.5, Double.NEGATIVE_INFINITY)
-        ));
+        assertThat(
+                goThroughTsvLineAndPickUpExpressionsByIndex.apply(
+                        new String[]{id, name, P_VAL_1, FOLD_CHANGE_1, P_VAL_2, "-Inf"})
+                        .getExpression(g1_g3),
+                is(new DifferentialExpression(0.5, Double.NEGATIVE_INFINITY)));
     }
 
     @Test
-    public void ignoreNAValues() throws Exception {
-
-        assertThat(goThroughTsvLineAndPickUpExpressionsByIndex.apply(new String[]{id, name, P_VAL_1, FOLD_CHANGE_1, "NA", "NA"}).getSpecificity(), is(1L));
-        assertThat(goThroughTsvLineAndPickUpExpressionsByIndex.apply(new String[]{id, name, "NA", "NA", P_VAL_1, FOLD_CHANGE_1}).getSpecificity(), is(1L));
-        assertThat(goThroughTsvLineAndPickUpExpressionsByIndex.apply(new String[]{id, name, P_VAL_1, FOLD_CHANGE_1, P_VAL_2, FOLD_CHANGE_2}).getSpecificity(), is(2L));
+    public void ignoreNAValues() {
+        assertThat(
+                goThroughTsvLineAndPickUpExpressionsByIndex.apply(
+                        new String[]{id, name, P_VAL_1, FOLD_CHANGE_1, "NA", "NA"}).getSpecificity(),
+                is(1L));
+        assertThat(
+                goThroughTsvLineAndPickUpExpressionsByIndex.apply(
+                        new String[]{id, name, "NA", "NA", P_VAL_1, FOLD_CHANGE_1}).getSpecificity(),
+                is(1L));
+        assertThat(
+                goThroughTsvLineAndPickUpExpressionsByIndex.apply(
+                        new String[]{id, name, P_VAL_1, FOLD_CHANGE_1, P_VAL_2, FOLD_CHANGE_2}).getSpecificity(),
+                is(2L));
     }
 }

--- a/base/src/test/java/uk/ac/ebi/atlas/profiles/stream/RnaSeqProfileStreamFactoryTest.java
+++ b/base/src/test/java/uk/ac/ebi/atlas/profiles/stream/RnaSeqProfileStreamFactoryTest.java
@@ -18,23 +18,26 @@ import java.util.Optional;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static uk.ac.ebi.atlas.testutils.MockExperiment.createDifferentialExperiment;
 
 public class RnaSeqProfileStreamFactoryTest {
 
-    MockDataFileHub dataFileHub;
+    private MockDataFileHub dataFileHub;
 
-    RnaSeqProfileStreamFactory subject;
+    private RnaSeqProfileStreamFactory subject;
 
-    AssayGroup g1 = new AssayGroup("g1", "assay_1");
-    AssayGroup g2 = new AssayGroup("g2", "assay_2");
-    AssayGroup g3 = new AssayGroup("g3", "assay_3");
+    private static final AssayGroup g1 = new AssayGroup("g1", "assay_1");
+    private static final AssayGroup g2 = new AssayGroup("g2", "assay_2");
+    private static final AssayGroup g3 = new AssayGroup("g3", "assay_3");
 
-    Contrast g1_g2 = new Contrast("g1_g2", null, g1, g2, "contrast 1");
-    Contrast g1_g3 = new Contrast("g1_g3", null, g1, g3, "contrast 2");
+    private static final Contrast g1_g2 = new Contrast("g1_g2", null, g1, g2, "contrast 1");
+    private static final Contrast g1_g3 = new Contrast("g1_g3", null, g1, g3, "contrast 2");
 
-    DifferentialExperiment experiment = DifferentialExperimentTest.mockExperiment("accession", ImmutableList.of(g1_g2, g1_g3));
+    private static final DifferentialExperiment experiment =
+            createDifferentialExperiment("accession", ImmutableList.of(g1_g2, g1_g3));
 
-    String[] header = new String[]{"Gene ID", "Gene Name", "g1_g2.p-value", "g1_g2.log2foldchange", "g1_g3.p-value", "g1_g3.log2foldchange"};
+    private static final String[] header =
+            new String[]{"Gene ID", "Gene Name", "g1_g2.p-value", "g1_g2.log2foldchange", "g1_g3.p-value", "g1_g3.log2foldchange"};
 
     @Before
     public void setUp() throws Exception {
@@ -42,35 +45,36 @@ public class RnaSeqProfileStreamFactoryTest {
         subject = new RnaSeqProfileStreamFactory(dataFileHub);
     }
 
-    void testCaseNoExpressionFilter(List<String[]> dataLines, Collection<String> getGeneIds, List<RnaSeqProfile> expected) {
+    private void testCaseNoExpressionFilter(List<String[]> dataLines, Collection<String> getGeneIds, List<RnaSeqProfile> expected) {
         DifferentialRequestPreferences differentialRequestPreferences = new DifferentialRequestPreferences();
         differentialRequestPreferences.setFoldChangeCutoff(0.0);
         differentialRequestPreferences.setCutoff(1.0);
         testCase(dataLines, getGeneIds, expected, differentialRequestPreferences);
     }
 
-    void testCaseNoCutoff(List<String[]> dataLines, Regulation regulation, List<RnaSeqProfile> expected) {
+    private void testCaseNoCutoff(List<String[]> dataLines, Regulation regulation, List<RnaSeqProfile> expected) {
         DifferentialRequestPreferences differentialRequestPreferences = new DifferentialRequestPreferences();
         differentialRequestPreferences.setFoldChangeCutoff(0.0);
         differentialRequestPreferences.setCutoff(1.0);
         differentialRequestPreferences.setRegulation(regulation);
         testCase(dataLines, Collections.emptySet(), expected, differentialRequestPreferences);
     }
-    void testCaseFoldChangeCutoff(List<String[]> dataLines, Double foldChangeCutoff, List<RnaSeqProfile> expected) {
+
+    private void testCaseFoldChangeCutoff(List<String[]> dataLines, Double foldChangeCutoff, List<RnaSeqProfile> expected) {
         DifferentialRequestPreferences differentialRequestPreferences = new DifferentialRequestPreferences();
         differentialRequestPreferences.setFoldChangeCutoff(foldChangeCutoff);
         differentialRequestPreferences.setCutoff(1.0);
         testCase(dataLines, Collections.emptySet(), expected, differentialRequestPreferences);
     }
 
-    void testCasePValueCutoff(List<String[]> dataLines, Double pValueCutoff, List<RnaSeqProfile> expected) {
+    private void testCasePValueCutoff(List<String[]> dataLines, Double pValueCutoff, List<RnaSeqProfile> expected) {
         DifferentialRequestPreferences differentialRequestPreferences = new DifferentialRequestPreferences();
         differentialRequestPreferences.setFoldChangeCutoff(0.0);
         differentialRequestPreferences.setCutoff(pValueCutoff);
         testCase(dataLines, Collections.emptySet(), expected, differentialRequestPreferences);
     }
 
-    void testCase(List<String[]> dataLines, Collection<String> getGeneIds, List<RnaSeqProfile> expected, DifferentialRequestPreferences differentialRequestPreferences) {
+    private void testCase(List<String[]> dataLines, Collection<String> getGeneIds, List<RnaSeqProfile> expected, DifferentialRequestPreferences differentialRequestPreferences) {
         dataFileHub.addRnaSeqAnalyticsFile(experiment.getAccession(), dataLines);
         assertThat(
                 ImmutableList.copyOf(
@@ -80,7 +84,7 @@ public class RnaSeqProfileStreamFactoryTest {
         );
     }
 
-    RnaSeqProfile profile(String id, String name,
+    private RnaSeqProfile profile(String id, String name,
                           DifferentialExpression expressionForG1_G2,
                           DifferentialExpression expressionForG1_G3) {
         RnaSeqProfile profile = new RnaSeqProfile(id, name);

--- a/gxa/src/main/java/uk/ac/ebi/atlas/experimentpage/json/JsonDifferentialExperimentController.java
+++ b/gxa/src/main/java/uk/ac/ebi/atlas/experimentpage/json/JsonDifferentialExperimentController.java
@@ -1,8 +1,6 @@
 package uk.ac.ebi.atlas.experimentpage.json;
 
-import com.google.common.collect.ImmutableSet;
 import org.springframework.context.annotation.Scope;
-import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.annotation.InitBinder;
@@ -17,7 +15,6 @@ import uk.ac.ebi.atlas.experimentpage.context.RnaSeqRequestContext;
 import uk.ac.ebi.atlas.experimentpage.differential.DifferentialExperimentPageService;
 import uk.ac.ebi.atlas.experimentpage.differential.DifferentialProfilesHeatMap;
 import uk.ac.ebi.atlas.experimentpage.differential.DifferentialRequestPreferencesValidator;
-import uk.ac.ebi.atlas.experimentpage.differential.evidence.EvidenceService;
 import uk.ac.ebi.atlas.model.experiment.differential.DifferentialExperiment;
 import uk.ac.ebi.atlas.model.experiment.differential.DifferentialExpression;
 import uk.ac.ebi.atlas.model.experiment.differential.microarray.MicroarrayExperiment;
@@ -27,20 +24,15 @@ import uk.ac.ebi.atlas.model.experiment.differential.rnaseq.RnaSeqProfile;
 import uk.ac.ebi.atlas.profiles.stream.MicroarrayProfileStreamFactory;
 import uk.ac.ebi.atlas.profiles.stream.RnaSeqProfileStreamFactory;
 import uk.ac.ebi.atlas.resource.AtlasResourceHub;
-import uk.ac.ebi.atlas.resource.DataFileHub;
 import uk.ac.ebi.atlas.solr.bioentities.query.SolrQueryService;
 import uk.ac.ebi.atlas.trader.ExperimentTrader;
 import uk.ac.ebi.atlas.web.DifferentialRequestPreferences;
 import uk.ac.ebi.atlas.web.MicroarrayRequestPreferences;
 
 import javax.inject.Inject;
-import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
-import java.io.IOException;
-import java.io.PrintWriter;
 
 import static uk.ac.ebi.atlas.utils.GsonProvider.GSON;
-
 
 @Controller
 @Scope("request")
@@ -60,24 +52,13 @@ public class JsonDifferentialExperimentController extends JsonExperimentControll
                 MicroarrayProfile, MicroarrayRequestContext>
             diffMicroarrayExperimentPageService;
 
-    private final
-        EvidenceService<DifferentialExpression, DifferentialExperiment, RnaSeqRequestContext, RnaSeqProfile>
-            diffRnaSeqEvidenceService;
-    private final
-        EvidenceService<MicroarrayExpression, MicroarrayExperiment, MicroarrayRequestContext, MicroarrayProfile>
-            diffMicroarrayEvidenceService;
-
-
     @Inject
     public JsonDifferentialExperimentController(ExperimentTrader experimentTrader,
                                                 RnaSeqProfileStreamFactory rnaSeqProfileStreamFactory,
                                                 MicroarrayProfileStreamFactory microarrayProfileStreamFactory,
                                                 SolrQueryService solrQueryService,
-                                                AtlasResourceHub atlasResourceHub,
-                                                DataFileHub dataFileHub,
-                                                Environment props) {
+                                                AtlasResourceHub atlasResourceHub) {
         super(experimentTrader);
-        String resourcesVersion = props.getProperty("projectVersion");
 
         diffRnaSeqExperimentPageService =
                 new DifferentialExperimentPageService<>(new DifferentialRequestContextFactory.RnaSeq(),
@@ -88,11 +69,6 @@ public class JsonDifferentialExperimentController extends JsonExperimentControll
                 new DifferentialExperimentPageService<>(new DifferentialRequestContextFactory.Microarray(),
                         new DifferentialProfilesHeatMap<>(microarrayProfileStreamFactory, solrQueryService),
                         atlasResourceHub);
-        diffRnaSeqEvidenceService =
-                new EvidenceService<>(rnaSeqProfileStreamFactory, dataFileHub, resourcesVersion);
-        diffMicroarrayEvidenceService =
-                new EvidenceService<>(microarrayProfileStreamFactory, dataFileHub, resourcesVersion);
-
     }
 
     @RequestMapping(value = "/json/experiments/{experimentAccession}",
@@ -119,52 +95,5 @@ public class JsonDifferentialExperimentController extends JsonExperimentControll
         return GSON.toJson(diffRnaSeqExperimentPageService.getResultsForExperiment(
                 (DifferentialExperiment) experimentTrader.getExperiment(experimentAccession, accessKey),
                 accessKey, preferences));
-    }
-
-    /*
-    View of experiment as set of evidence between genes and diseases, in the Open Targets format.
-    Returns an empty response for experiments that are not about diseases or that we have no evidence for.
-     */
-    @RequestMapping(value = "/json/experiments/{experimentAccession}/evidence",
-            produces = "application/json-seq;charset=UTF-8",
-            params = "type=MICROARRAY_ANY")
-    public void differentialMicroarrayExperimentEvidence(
-            @RequestParam(defaultValue = "0") double logFoldChangeCutoff,
-            @RequestParam(defaultValue = "1") double pValueCutoff,
-            @RequestParam(defaultValue = "-1") int maxGenesPerContrast,
-            @PathVariable String experimentAccession,
-            @RequestParam(defaultValue = "") String accessKey, HttpServletResponse response) throws IOException {
-        MicroarrayExperiment experiment = (MicroarrayExperiment) experimentTrader.getExperiment(experimentAccession, accessKey);
-        PrintWriter w = response.getWriter();
-        diffMicroarrayEvidenceService.evidenceForExperiment(experiment,contrast -> {
-            MicroarrayRequestPreferences requestPreferences = new MicroarrayRequestPreferences();
-            requestPreferences.setFoldChangeCutoff(logFoldChangeCutoff);
-            requestPreferences.setCutoff(pValueCutoff);
-            requestPreferences.setHeatmapMatrixSize(maxGenesPerContrast);
-            requestPreferences.setSelectedColumnIds(ImmutableSet.of(contrast.getId()));
-            return new MicroarrayRequestContext(requestPreferences, experiment);
-        }, o -> w.println(GSON.toJson(o)));
-
-    }
-
-    @RequestMapping(value = "/json/experiments/{experimentAccession}/evidence",
-            produces = "application/json-seq;charset=UTF-8",
-            params = "type=RNASEQ_MRNA_DIFFERENTIAL")
-    public void differentialRnaSeqExperimentEvidence(
-            @RequestParam(defaultValue = "0") double logFoldChangeCutoff,
-            @RequestParam(defaultValue = "1") double pValueCutoff,
-            @RequestParam(defaultValue = "-1") int maxGenesPerContrast,
-            @PathVariable String experimentAccession,
-            @RequestParam(defaultValue = "") String accessKey, HttpServletResponse response) throws IOException {
-        DifferentialExperiment experiment = (DifferentialExperiment) experimentTrader.getExperiment(experimentAccession, accessKey);
-        PrintWriter w = response.getWriter();
-        diffRnaSeqEvidenceService.evidenceForExperiment(experiment, contrast -> {
-            DifferentialRequestPreferences requestPreferences = new DifferentialRequestPreferences();
-            requestPreferences.setFoldChangeCutoff(logFoldChangeCutoff);
-            requestPreferences.setCutoff(pValueCutoff);
-            requestPreferences.setHeatmapMatrixSize(maxGenesPerContrast);
-            requestPreferences.setSelectedColumnIds(ImmutableSet.of(contrast.getId()));
-            return new RnaSeqRequestContext(requestPreferences, experiment);
-        }, o-> w.println(GSON.toJson(o)));
     }
 }

--- a/gxa/src/main/java/uk/ac/ebi/atlas/experimentpage/json/opentargets/OpenTargetsEvidenceController.java
+++ b/gxa/src/main/java/uk/ac/ebi/atlas/experimentpage/json/opentargets/OpenTargetsEvidenceController.java
@@ -1,0 +1,112 @@
+package uk.ac.ebi.atlas.experimentpage.json.opentargets;
+
+import com.google.common.collect.ImmutableSet;
+import org.springframework.context.annotation.Scope;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.WebDataBinder;
+import org.springframework.web.bind.annotation.InitBinder;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import uk.ac.ebi.atlas.experimentpage.context.MicroarrayRequestContext;
+import uk.ac.ebi.atlas.experimentpage.context.RnaSeqRequestContext;
+import uk.ac.ebi.atlas.experimentpage.differential.DifferentialRequestPreferencesValidator;
+import uk.ac.ebi.atlas.experimentpage.json.JsonExperimentController;
+import uk.ac.ebi.atlas.model.experiment.differential.DifferentialExperiment;
+import uk.ac.ebi.atlas.model.experiment.differential.DifferentialExpression;
+import uk.ac.ebi.atlas.model.experiment.differential.microarray.MicroarrayExperiment;
+import uk.ac.ebi.atlas.model.experiment.differential.microarray.MicroarrayExpression;
+import uk.ac.ebi.atlas.model.experiment.differential.microarray.MicroarrayProfile;
+import uk.ac.ebi.atlas.model.experiment.differential.rnaseq.RnaSeqProfile;
+import uk.ac.ebi.atlas.profiles.stream.MicroarrayProfileStreamFactory;
+import uk.ac.ebi.atlas.profiles.stream.RnaSeqProfileStreamFactory;
+import uk.ac.ebi.atlas.resource.DataFileHub;
+import uk.ac.ebi.atlas.trader.ExperimentTrader;
+import uk.ac.ebi.atlas.web.DifferentialRequestPreferences;
+import uk.ac.ebi.atlas.web.MicroarrayRequestPreferences;
+
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import static uk.ac.ebi.atlas.utils.GsonProvider.GSON;
+
+// View of experiment as set of evidence between genes and diseases, in the Open Targets format.
+// Returns an empty response for experiments that are not about diseases or that we have no evidence for.
+@Controller
+@Scope("request")
+public class OpenTargetsEvidenceController extends JsonExperimentController {
+
+    @InitBinder("preferences")
+    void initBinder(WebDataBinder binder) {
+        binder.addValidators(new DifferentialRequestPreferencesValidator());
+    }
+
+    private final
+        EvidenceService<DifferentialExpression, DifferentialExperiment, RnaSeqRequestContext, RnaSeqProfile>
+            diffRnaSeqEvidenceService;
+    private final
+        EvidenceService<MicroarrayExpression, MicroarrayExperiment, MicroarrayRequestContext, MicroarrayProfile>
+            diffMicroarrayEvidenceService;
+
+
+    @Inject
+    public OpenTargetsEvidenceController(ExperimentTrader experimentTrader,
+                                         RnaSeqProfileStreamFactory rnaSeqProfileStreamFactory,
+                                         MicroarrayProfileStreamFactory microarrayProfileStreamFactory,
+                                         DataFileHub dataFileHub,
+                                         Environment props) {
+        super(experimentTrader);
+        String resourcesVersion = props.getProperty("projectVersion");
+
+        diffRnaSeqEvidenceService =
+                new EvidenceService<>(rnaSeqProfileStreamFactory, dataFileHub, resourcesVersion);
+        diffMicroarrayEvidenceService =
+                new EvidenceService<>(microarrayProfileStreamFactory, dataFileHub, resourcesVersion);
+    }
+
+    @RequestMapping(value = "/json/experiments/{experimentAccession}/evidence",
+            produces = "application/json-seq;charset=UTF-8",
+            params = "type=MICROARRAY_ANY")
+    public void differentialMicroarrayExperimentEvidence(
+            @RequestParam(defaultValue = "0") double logFoldChangeCutoff,
+            @RequestParam(defaultValue = "1") double pValueCutoff,
+            @RequestParam(defaultValue = "-1") int maxGenesPerContrast,
+            @PathVariable String experimentAccession,
+            @RequestParam(defaultValue = "") String accessKey, HttpServletResponse response) throws IOException {
+        MicroarrayExperiment experiment = (MicroarrayExperiment) experimentTrader.getExperiment(experimentAccession, accessKey);
+        PrintWriter w = response.getWriter();
+        diffMicroarrayEvidenceService.evidenceForExperiment(experiment,contrast -> {
+            MicroarrayRequestPreferences requestPreferences = new MicroarrayRequestPreferences();
+            requestPreferences.setFoldChangeCutoff(logFoldChangeCutoff);
+            requestPreferences.setCutoff(pValueCutoff);
+            requestPreferences.setHeatmapMatrixSize(maxGenesPerContrast);
+            requestPreferences.setSelectedColumnIds(ImmutableSet.of(contrast.getId()));
+            return new MicroarrayRequestContext(requestPreferences, experiment);
+        }, o -> w.println(GSON.toJson(o)));
+
+    }
+
+    @RequestMapping(value = "/json/experiments/{experimentAccession}/evidence",
+            produces = "application/json-seq;charset=UTF-8",
+            params = "type=RNASEQ_MRNA_DIFFERENTIAL")
+    public void differentialRnaSeqExperimentEvidence(
+            @RequestParam(defaultValue = "0") double logFoldChangeCutoff,
+            @RequestParam(defaultValue = "1") double pValueCutoff,
+            @RequestParam(defaultValue = "-1") int maxGenesPerContrast,
+            @PathVariable String experimentAccession,
+            @RequestParam(defaultValue = "") String accessKey, HttpServletResponse response) throws IOException {
+        DifferentialExperiment experiment = (DifferentialExperiment) experimentTrader.getExperiment(experimentAccession, accessKey);
+        PrintWriter w = response.getWriter();
+        diffRnaSeqEvidenceService.evidenceForExperiment(experiment, contrast -> {
+            DifferentialRequestPreferences requestPreferences = new DifferentialRequestPreferences();
+            requestPreferences.setFoldChangeCutoff(logFoldChangeCutoff);
+            requestPreferences.setCutoff(pValueCutoff);
+            requestPreferences.setHeatmapMatrixSize(maxGenesPerContrast);
+            requestPreferences.setSelectedColumnIds(ImmutableSet.of(contrast.getId()));
+            return new RnaSeqRequestContext(requestPreferences, experiment);
+        }, o-> w.println(GSON.toJson(o)));
+    }
+}

--- a/gxa/src/test/java/uk/ac/ebi/atlas/experimentpage/json/opentargets/EvidenceServiceIT.java
+++ b/gxa/src/test/java/uk/ac/ebi/atlas/experimentpage/json/opentargets/EvidenceServiceIT.java
@@ -1,4 +1,4 @@
-package uk.ac.ebi.atlas.experimentpage.differential;
+package uk.ac.ebi.atlas.experimentpage.json.opentargets;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -11,7 +11,6 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 import uk.ac.ebi.atlas.configuration.WebConfig;
 import uk.ac.ebi.atlas.experimentpage.context.MicroarrayRequestContext;
-import uk.ac.ebi.atlas.experimentpage.differential.evidence.EvidenceService;
 
 import uk.ac.ebi.atlas.model.experiment.differential.microarray.MicroarrayExperiment;
 import uk.ac.ebi.atlas.model.experiment.differential.microarray.MicroarrayExpression;
@@ -23,7 +22,8 @@ import uk.ac.ebi.atlas.web.MicroarrayRequestPreferences;
 
 import javax.inject.Inject;
 
-import static org.hamcrest.Matchers.isEmptyString;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 
@@ -31,26 +31,25 @@ import static org.junit.Assert.assertThat;
 @WebAppConfiguration
 @ContextConfiguration(classes = {WebConfig.class})
 public class EvidenceServiceIT {
+    @Inject
+    private ExpressionAtlasExperimentTrader experimentTrader;
 
     @Inject
-    ExpressionAtlasExperimentTrader experimentTrader;
+    private MicroarrayProfileStreamFactory microarrayProfileStreamFactory;
 
     @Inject
-    MicroarrayProfileStreamFactory microarrayProfileStreamFactory;
+    private DataFileHub dataFileHub;
 
-    @Inject
-    DataFileHub dataFileHub;
-
-    EvidenceService<MicroarrayExpression, MicroarrayExperiment, MicroarrayRequestContext, MicroarrayProfile>
+    private EvidenceService<MicroarrayExpression, MicroarrayExperiment, MicroarrayRequestContext, MicroarrayProfile>
             subject;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         subject = new EvidenceService<>(microarrayProfileStreamFactory, dataFileHub, "test");
     }
 
     @Test
-    public void organismPartIsIncludedIfAvailable() throws Exception {
+    public void organismPartIsIncludedIfAvailable() {
         ImmutableList.Builder<JsonObject> listBuilder = ImmutableList.builder();
         MicroarrayExperiment experiment = (MicroarrayExperiment) experimentTrader.getPublicExperiment("E-GEOD-12685");
         subject.evidenceForExperiment(experiment, contrast -> {
@@ -65,7 +64,7 @@ public class EvidenceServiceIT {
         for (JsonObject jsonObject : listBuilder.build()) {
             assertThat(
                     jsonObject.get("evidence").getAsJsonObject().get("organism_part").getAsString(),
-                    not(isEmptyString()));
+                    is(not(emptyString())));
         }
     }
 }


### PR DESCRIPTION
* WIP: adding probe ID field to JSON dump.

* Populated probeId field with the correct value, depending on the type of experiment.

* Split experiment JSON controller in two; repackage OT dump classes and sanitise test to get rid of a warning

* Move and rename mockExperiment in test class to test utils MockExperiment

* Repackage test class and use new test utils to mock differential experiments

* Rename controller
It conflicts with uk.ac.ebi.atlas.experimentpage.json.JsonDifferentialExperimentController