### PR TITLE
Append trailing slash to resource location

### DIFF
--- a/gxa/src/main/java/uk/ac/ebi/atlas/configuration/WebConfig.java
+++ b/gxa/src/main/java/uk/ac/ebi/atlas/configuration/WebConfig.java
@@ -44,7 +44,7 @@ public class WebConfig extends WebMvcConfigurerAdapter {
                 .setCacheControl(CacheControl.maxAge(1, TimeUnit.HOURS).cachePublic());
 
         registry.addResourceHandler("/expdata/**")
-                .addResourceLocations("file:" + dataFileHub.getExperimentMageTabDirLocation());
+                .addResourceLocations("file:" + dataFileHub.getExperimentMageTabDirLocation() + "/");
     }
 
     @Override


### PR DESCRIPTION
Since dataFileHub.getExperimentMageTabDirLocation() returns a Path after the switch to Java-based configuration the trailing slash was omitted, causing all experiment static resources (Downloads tab) return a 404