### PR TITLE
Bugfix #159753830 – Fix ArrayExpress EFO suggestions

### DIFF
--- a/base/src/main/java/uk/ac/ebi/atlas/experiments/ExperimentMetadataEnrichmentService.java
+++ b/base/src/main/java/uk/ac/ebi/atlas/experiments/ExperimentMetadataEnrichmentService.java
@@ -1,6 +1,5 @@
 package uk.ac.ebi.atlas.experiments;
 
-import com.google.common.base.Optional;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -12,18 +11,17 @@ import uk.ac.ebi.atlas.trader.ExperimentTrader;
 
 import javax.annotation.Nullable;
 import java.text.MessageFormat;
+import java.util.Optional;
 
 public class ExperimentMetadataEnrichmentService {
-
     private final ExperimentTrader experimentTrader;
 
     public ExperimentMetadataEnrichmentService(ExperimentTrader experimentTrader) {
         this.experimentTrader = experimentTrader;
     }
 
-
     private String comparisonTitle(Experiment e, String chosenContrast) {
-        if (e != null && e instanceof DifferentialExperiment) {
+        if (e instanceof DifferentialExperiment) {
            Contrast c = ((DifferentialExperiment) e).getDataColumnDescriptor(chosenContrast);
             if (c != null) {
                 return c.getDisplayName();
@@ -33,7 +31,7 @@ public class ExperimentMetadataEnrichmentService {
     }
 
     private String experimentName(@Nullable Experiment experiment, String experimentAccession) {
-        return Optional.fromNullable(experiment).transform(e -> e.getDescription()).or(experimentAccession);
+        return Optional.ofNullable(experiment).map(Experiment::getDescription).orElse(experimentAccession);
     }
 
     private JsonObject nameWithUrl(String name, String url) {

--- a/gxa/src/main/webapp/WEB-INF/jsp/tiles/base.jsp
+++ b/gxa/src/main/webapp/WEB-INF/jsp/tiles/base.jsp
@@ -82,8 +82,9 @@
 
 <tiles:insertAttribute name="global-footer"/>
 
-<!-- JavaScript -->
+<!-- jQuery -->
 <script src="https://code.jquery.com/jquery-2.2.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-migrate-1.4.1.min.js"></script>
 
 <!-- Don’t defer or async, these two need to be loaded before other bundles, which are effectively deferred -->
 <script src="${pageContext.request.contextPath}/resources/js/lib/babel-polyfill.min.js"></script>


### PR DESCRIPTION
The browser was complaining about `$.browser` being `undefined`. It’s an old plugin that the EFO module still uses. Luckily it’s provided by [jQuery Migrate](https://github.com/jquery/jquery-migrate/).