### PR TITLE
Hotfix - Wrong titles shown for ArrayExpress experiments

### DIFF
--- a/base/src/main/java/uk/ac/ebi/atlas/trader/cache/loader/BaselineExperimentFactory.java
+++ b/base/src/main/java/uk/ac/ebi/atlas/trader/cache/loader/BaselineExperimentFactory.java
@@ -2,6 +2,7 @@ package uk.ac.ebi.atlas.trader.cache.loader;
 
 import org.apache.commons.lang3.tuple.Pair;
 import uk.ac.ebi.atlas.experimentimport.ExperimentDTO;
+import uk.ac.ebi.atlas.experimentimport.idf.IdfParserOutput;
 import uk.ac.ebi.atlas.model.experiment.ExperimentConfiguration;
 import uk.ac.ebi.atlas.model.experiment.ExperimentDesign;
 import uk.ac.ebi.atlas.model.experiment.ExperimentDisplayDefaults;
@@ -32,11 +33,13 @@ public abstract class BaselineExperimentFactory implements ExperimentFactory<Bas
 
     @Override
     public BaselineExperiment create(ExperimentDTO experimentDTO,
-                                     ExperimentDesign experimentDesign) {
+                                     ExperimentDesign experimentDesign,
+                                     IdfParserOutput idfParserOutput) {
 
         String experimentAccession = experimentDTO.getExperimentAccession();
 
         ExperimentConfiguration configuration = configurationTrader.getExperimentConfiguration(experimentAccession);
+        // Configuration coming from the factors.xml file
         BaselineExperimentConfiguration factorsConfig =
                 configurationTrader.getBaselineFactorsConfiguration(experimentAccession);
 
@@ -45,7 +48,7 @@ public abstract class BaselineExperimentFactory implements ExperimentFactory<Bas
                 .forSpecies(speciesFactory.create(experimentDTO.getSpecies()))
                 .withAccession(experimentAccession)
                 .withLastUpdate(experimentDTO.getLastUpdate())
-                .withDescription(experimentDTO.getTitle())
+                .withDescription(idfParserOutput.getTitle())
                 .withDisclaimer(factorsConfig.disclaimer())
                 .withDisplayName(factorsConfig.getExperimentDisplayName())
                 .withPubMedIds(experimentDTO.getPubmedIds())

--- a/base/src/main/java/uk/ac/ebi/atlas/trader/cache/loader/ExperimentFactory.java
+++ b/base/src/main/java/uk/ac/ebi/atlas/trader/cache/loader/ExperimentFactory.java
@@ -1,10 +1,12 @@
 package uk.ac.ebi.atlas.trader.cache.loader;
 
 import uk.ac.ebi.atlas.experimentimport.ExperimentDTO;
+import uk.ac.ebi.atlas.experimentimport.idf.IdfParserOutput;
 import uk.ac.ebi.atlas.model.experiment.Experiment;
 import uk.ac.ebi.atlas.model.experiment.ExperimentDesign;
 
 public interface ExperimentFactory<E extends Experiment> {
     E create(ExperimentDTO experimentDTO,
-       ExperimentDesign experimentDesign);
+             ExperimentDesign experimentDesign,
+             IdfParserOutput idfParserOutput);
 }

--- a/base/src/main/java/uk/ac/ebi/atlas/trader/cache/loader/ExperimentsCacheLoader.java
+++ b/base/src/main/java/uk/ac/ebi/atlas/trader/cache/loader/ExperimentsCacheLoader.java
@@ -5,6 +5,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.ac.ebi.atlas.experimentimport.ExperimentDTO;
 import uk.ac.ebi.atlas.experimentimport.ExperimentDao;
+import uk.ac.ebi.atlas.experimentimport.idf.IdfParser;
+import uk.ac.ebi.atlas.experimentimport.idf.IdfParserOutput;
 import uk.ac.ebi.atlas.model.experiment.Experiment;
 import uk.ac.ebi.atlas.model.experiment.ExperimentDesign;
 import uk.ac.ebi.atlas.trader.ExperimentDesignParser;
@@ -17,13 +19,16 @@ public class ExperimentsCacheLoader<T extends Experiment> extends CacheLoader<St
     private final ExperimentDesignParser experimentDesignParser;
     private final ExperimentDao experimentDao;
     private final ExperimentFactory<T> experimentFactory;
+    private final IdfParser idfParser;
 
     public ExperimentsCacheLoader(ExperimentDesignParser experimentDesignParser,
                                   ExperimentDao experimentDao,
-                                  ExperimentFactory<T> experimentFactory) {
+                                  ExperimentFactory<T> experimentFactory,
+                                  IdfParser idfParser) {
         this.experimentDesignParser = experimentDesignParser;
         this.experimentDao = experimentDao;
         this.experimentFactory = experimentFactory;
+        this.idfParser = idfParser;
     }
 
     @Override
@@ -32,7 +37,8 @@ public class ExperimentsCacheLoader<T extends Experiment> extends CacheLoader<St
 
         ExperimentDTO experimentDTO = experimentDao.getExperimentAsAdmin(experimentAccession);
         ExperimentDesign experimentDesign = experimentDesignParser.parse(experimentAccession);
+        IdfParserOutput idfParserOutput = idfParser.parse(experimentAccession);
 
-        return experimentFactory.create(experimentDTO, experimentDesign);
+        return experimentFactory.create(experimentDTO, experimentDesign, idfParserOutput);
     }
 }

--- a/gxa/src/main/java/uk/ac/ebi/atlas/trader/cache/CacheConfiguration.java
+++ b/gxa/src/main/java/uk/ac/ebi/atlas/trader/cache/CacheConfiguration.java
@@ -24,7 +24,9 @@ public class CacheConfiguration {
     private final GxaExperimentDao experimentDao;
     private final IdfParser idfParser;
 
-    public CacheConfiguration(ExperimentDesignParser experimentDesignParser, GxaExperimentDao experimentDao, IdfParser idfParser) {
+    public CacheConfiguration(ExperimentDesignParser experimentDesignParser,
+                              GxaExperimentDao experimentDao,
+                              IdfParser idfParser) {
         this.experimentDesignParser = experimentDesignParser;
         this.experimentDao = experimentDao;
         this.idfParser = idfParser;
@@ -36,7 +38,8 @@ public class CacheConfiguration {
     baselineExperimentsCache(RnaSeqBaselineExperimentFactory experimentFactory) {
 
         return CacheBuilder.newBuilder()
-                .build(new ExperimentsCacheLoader<>(experimentDesignParser, experimentDao, experimentFactory, idfParser));
+                .build(new ExperimentsCacheLoader<>(
+                        experimentDesignParser, experimentDao, experimentFactory, idfParser));
     }
 
     @Bean(name = "proteomicsBaselineExperimentsLoadingCache")
@@ -45,7 +48,8 @@ public class CacheConfiguration {
     proteomicsBaselineExperimentsCache(ProteomicsBaselineExperimentFactory experimentFactory) {
 
         return CacheBuilder.newBuilder()
-                .build(new ExperimentsCacheLoader<>(experimentDesignParser, experimentDao, experimentFactory, idfParser));
+                .build(new ExperimentsCacheLoader<>(
+                        experimentDesignParser, experimentDao, experimentFactory, idfParser));
     }
 
 
@@ -55,7 +59,8 @@ public class CacheConfiguration {
     differentialExperimentsCache(DifferentialExperimentFactory experimentFactory) {
 
         return CacheBuilder.newBuilder()
-                .build(new ExperimentsCacheLoader<>(experimentDesignParser, experimentDao, experimentFactory, idfParser));
+                .build(new ExperimentsCacheLoader<>(
+                        experimentDesignParser, experimentDao, experimentFactory, idfParser));
     }
 
     @Bean(name = "microarrayExperimentsLoadingCache")
@@ -64,6 +69,7 @@ public class CacheConfiguration {
     microarrayExperimentsCache(MicroarrayExperimentFactory experimentFactory) {
 
         return CacheBuilder.newBuilder()
-                .build(new ExperimentsCacheLoader<>(experimentDesignParser, experimentDao, experimentFactory, idfParser));
+                .build(new ExperimentsCacheLoader<>(
+                        experimentDesignParser, experimentDao, experimentFactory, idfParser));
     }
 }

--- a/gxa/src/main/java/uk/ac/ebi/atlas/trader/cache/CacheConfiguration.java
+++ b/gxa/src/main/java/uk/ac/ebi/atlas/trader/cache/CacheConfiguration.java
@@ -5,6 +5,7 @@ import com.google.common.cache.LoadingCache;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import uk.ac.ebi.atlas.experimentimport.GxaExperimentDao;
+import uk.ac.ebi.atlas.experimentimport.idf.IdfParser;
 import uk.ac.ebi.atlas.model.experiment.baseline.BaselineExperiment;
 import uk.ac.ebi.atlas.model.experiment.differential.DifferentialExperiment;
 import uk.ac.ebi.atlas.model.experiment.differential.microarray.MicroarrayExperiment;
@@ -21,10 +22,12 @@ import javax.inject.Inject;
 public class CacheConfiguration {
     private final ExperimentDesignParser experimentDesignParser;
     private final GxaExperimentDao experimentDao;
+    private final IdfParser idfParser;
 
-    public CacheConfiguration(ExperimentDesignParser experimentDesignParser, GxaExperimentDao experimentDao) {
+    public CacheConfiguration(ExperimentDesignParser experimentDesignParser, GxaExperimentDao experimentDao, IdfParser idfParser) {
         this.experimentDesignParser = experimentDesignParser;
         this.experimentDao = experimentDao;
+        this.idfParser = idfParser;
     }
 
     @Bean(name = "rnaSeqBaselineExperimentsLoadingCache")
@@ -33,7 +36,7 @@ public class CacheConfiguration {
     baselineExperimentsCache(RnaSeqBaselineExperimentFactory experimentFactory) {
 
         return CacheBuilder.newBuilder()
-                .build(new ExperimentsCacheLoader<>(experimentDesignParser, experimentDao, experimentFactory));
+                .build(new ExperimentsCacheLoader<>(experimentDesignParser, experimentDao, experimentFactory, idfParser));
     }
 
     @Bean(name = "proteomicsBaselineExperimentsLoadingCache")
@@ -42,7 +45,7 @@ public class CacheConfiguration {
     proteomicsBaselineExperimentsCache(ProteomicsBaselineExperimentFactory experimentFactory) {
 
         return CacheBuilder.newBuilder()
-                .build(new ExperimentsCacheLoader<>(experimentDesignParser, experimentDao, experimentFactory));
+                .build(new ExperimentsCacheLoader<>(experimentDesignParser, experimentDao, experimentFactory, idfParser));
     }
 
 
@@ -52,7 +55,7 @@ public class CacheConfiguration {
     differentialExperimentsCache(DifferentialExperimentFactory experimentFactory) {
 
         return CacheBuilder.newBuilder()
-                .build(new ExperimentsCacheLoader<>(experimentDesignParser, experimentDao, experimentFactory));
+                .build(new ExperimentsCacheLoader<>(experimentDesignParser, experimentDao, experimentFactory, idfParser));
     }
 
     @Bean(name = "microarrayExperimentsLoadingCache")
@@ -61,6 +64,6 @@ public class CacheConfiguration {
     microarrayExperimentsCache(MicroarrayExperimentFactory experimentFactory) {
 
         return CacheBuilder.newBuilder()
-                .build(new ExperimentsCacheLoader<>(experimentDesignParser, experimentDao, experimentFactory));
+                .build(new ExperimentsCacheLoader<>(experimentDesignParser, experimentDao, experimentFactory, idfParser));
     }
 }

--- a/gxa/src/main/java/uk/ac/ebi/atlas/trader/cache/loader/BaselineExperimentFactory.java
+++ b/gxa/src/main/java/uk/ac/ebi/atlas/trader/cache/loader/BaselineExperimentFactory.java
@@ -17,7 +17,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 public abstract class BaselineExperimentFactory implements ExperimentFactory<BaselineExperiment> {
-
     private final ExperimentType experimentType;
     private final ConfigurationTrader configurationTrader;
     private final SpeciesFactory speciesFactory;
@@ -29,7 +28,6 @@ public abstract class BaselineExperimentFactory implements ExperimentFactory<Bas
         this.configurationTrader = configurationTrader;
         this.speciesFactory = speciesFactory;
     }
-
 
     @Override
     public BaselineExperiment create(ExperimentDTO experimentDTO,

--- a/gxa/src/main/java/uk/ac/ebi/atlas/trader/cache/loader/DifferentialExperimentFactory.java
+++ b/gxa/src/main/java/uk/ac/ebi/atlas/trader/cache/loader/DifferentialExperimentFactory.java
@@ -1,5 +1,6 @@
 package uk.ac.ebi.atlas.trader.cache.loader;
 
+import org.springframework.stereotype.Component;
 import uk.ac.ebi.atlas.experimentimport.ExperimentDTO;
 import uk.ac.ebi.atlas.experimentimport.idf.IdfParserOutput;
 import uk.ac.ebi.atlas.model.experiment.ExperimentConfiguration;
@@ -8,16 +9,11 @@ import uk.ac.ebi.atlas.model.experiment.differential.DifferentialExperiment;
 import uk.ac.ebi.atlas.species.SpeciesFactory;
 import uk.ac.ebi.atlas.trader.ConfigurationTrader;
 
-import javax.inject.Inject;
-import javax.inject.Named;
-
-@Named
+@Component
 public class DifferentialExperimentFactory implements ExperimentFactory<DifferentialExperiment> {
-
     private final ConfigurationTrader configurationTrader;
     private final SpeciesFactory speciesFactory;
 
-    @Inject
     public DifferentialExperimentFactory(ConfigurationTrader configurationTrader, SpeciesFactory speciesFactory) {
         this.configurationTrader = configurationTrader;
         this.speciesFactory = speciesFactory;
@@ -25,7 +21,8 @@ public class DifferentialExperimentFactory implements ExperimentFactory<Differen
 
     @Override
     public DifferentialExperiment create(ExperimentDTO experimentDTO,
-                                         ExperimentDesign experimentDesign, IdfParserOutput idfParserOutput) {
+                                         ExperimentDesign experimentDesign,
+                                         IdfParserOutput idfParserOutput) {
 
         String experimentAccession = experimentDTO.getExperimentAccession();
 

--- a/gxa/src/main/java/uk/ac/ebi/atlas/trader/cache/loader/DifferentialExperimentFactory.java
+++ b/gxa/src/main/java/uk/ac/ebi/atlas/trader/cache/loader/DifferentialExperimentFactory.java
@@ -1,6 +1,7 @@
 package uk.ac.ebi.atlas.trader.cache.loader;
 
 import uk.ac.ebi.atlas.experimentimport.ExperimentDTO;
+import uk.ac.ebi.atlas.experimentimport.idf.IdfParserOutput;
 import uk.ac.ebi.atlas.model.experiment.ExperimentConfiguration;
 import uk.ac.ebi.atlas.model.experiment.ExperimentDesign;
 import uk.ac.ebi.atlas.model.experiment.differential.DifferentialExperiment;
@@ -24,7 +25,7 @@ public class DifferentialExperimentFactory implements ExperimentFactory<Differen
 
     @Override
     public DifferentialExperiment create(ExperimentDTO experimentDTO,
-                                         ExperimentDesign experimentDesign) {
+                                         ExperimentDesign experimentDesign, IdfParserOutput idfParserOutput) {
 
         String experimentAccession = experimentDTO.getExperimentAccession();
 
@@ -35,7 +36,7 @@ public class DifferentialExperimentFactory implements ExperimentFactory<Differen
                 experimentAccession,
                 experimentDTO.getLastUpdate(),
                 experimentConfiguration.getContrastAndAnnotationPairs(),
-                experimentDTO.getTitle(),
+                idfParserOutput.getTitle(),
                 speciesFactory.create(experimentDTO.getSpecies()),
                 experimentDTO.getPubmedIds(),
                 experimentDTO.getDois(),

--- a/gxa/src/main/java/uk/ac/ebi/atlas/trader/cache/loader/MicroarrayExperimentFactory.java
+++ b/gxa/src/main/java/uk/ac/ebi/atlas/trader/cache/loader/MicroarrayExperimentFactory.java
@@ -2,6 +2,7 @@ package uk.ac.ebi.atlas.trader.cache.loader;
 
 import uk.ac.ebi.atlas.dao.ArrayDesignDAO;
 import uk.ac.ebi.atlas.experimentimport.ExperimentDTO;
+import uk.ac.ebi.atlas.experimentimport.idf.IdfParserOutput;
 import uk.ac.ebi.atlas.model.experiment.ExperimentDesign;
 import uk.ac.ebi.atlas.model.experiment.differential.microarray.MicroarrayExperiment;
 import uk.ac.ebi.atlas.model.experiment.differential.microarray.MicroarrayExperimentConfiguration;
@@ -32,7 +33,7 @@ public class MicroarrayExperimentFactory implements ExperimentFactory<Microarray
 
     @Override
     public MicroarrayExperiment create(ExperimentDTO experimentDTO,
-                                       ExperimentDesign experimentDesign) {
+                                       ExperimentDesign experimentDesign, IdfParserOutput idfParserOutput) {
 
         String experimentAccession = experimentDTO.getExperimentAccession();
 
@@ -44,7 +45,7 @@ public class MicroarrayExperimentFactory implements ExperimentFactory<Microarray
                 experimentAccession,
                 experimentDTO.getLastUpdate(),
                 experimentConfiguration.getContrastAndAnnotationPairs(),
-                experimentDTO.getTitle(),
+                idfParserOutput.getTitle(),
                 speciesFactory.create(experimentDTO.getSpecies()),
                 experimentDesign,
                 experimentDTO.getPubmedIds(),

--- a/gxa/src/main/java/uk/ac/ebi/atlas/trader/cache/loader/MicroarrayExperimentFactory.java
+++ b/gxa/src/main/java/uk/ac/ebi/atlas/trader/cache/loader/MicroarrayExperimentFactory.java
@@ -1,5 +1,6 @@
 package uk.ac.ebi.atlas.trader.cache.loader;
 
+import org.springframework.stereotype.Component;
 import uk.ac.ebi.atlas.dao.ArrayDesignDAO;
 import uk.ac.ebi.atlas.experimentimport.ExperimentDTO;
 import uk.ac.ebi.atlas.experimentimport.idf.IdfParserOutput;
@@ -9,18 +10,14 @@ import uk.ac.ebi.atlas.model.experiment.differential.microarray.MicroarrayExperi
 import uk.ac.ebi.atlas.species.SpeciesFactory;
 import uk.ac.ebi.atlas.trader.ConfigurationTrader;
 
-import javax.inject.Inject;
-import javax.inject.Named;
 import java.util.stream.Collectors;
 
-@Named
+@Component
 public class MicroarrayExperimentFactory implements ExperimentFactory<MicroarrayExperiment> {
-
     private final ConfigurationTrader configurationTrader;
     private final SpeciesFactory speciesFactory;
     private final ArrayDesignDAO arrayDesignDAO;
 
-    @Inject
     public MicroarrayExperimentFactory(ConfigurationTrader configurationTrader,
                                        SpeciesFactory speciesFactory,
                                        ArrayDesignDAO arrayDesignDAO) {
@@ -33,7 +30,8 @@ public class MicroarrayExperimentFactory implements ExperimentFactory<Microarray
 
     @Override
     public MicroarrayExperiment create(ExperimentDTO experimentDTO,
-                                       ExperimentDesign experimentDesign, IdfParserOutput idfParserOutput) {
+                                       ExperimentDesign experimentDesign,
+                                       IdfParserOutput idfParserOutput) {
 
         String experimentAccession = experimentDTO.getExperimentAccession();
 
@@ -53,10 +51,8 @@ public class MicroarrayExperimentFactory implements ExperimentFactory<Microarray
                 experimentConfiguration
                         .getArrayDesignAccessions()
                         .stream()
-                        .map(a -> arrayDesignDAO.getArrayDesign(a))
+                        .map(arrayDesignDAO::getArrayDesign)
                         .collect(Collectors.toList())
         );
-
     }
-
 }

--- a/gxa/src/main/java/uk/ac/ebi/atlas/trader/cache/loader/ProteomicsBaselineExperimentFactory.java
+++ b/gxa/src/main/java/uk/ac/ebi/atlas/trader/cache/loader/ProteomicsBaselineExperimentFactory.java
@@ -1,20 +1,14 @@
 package uk.ac.ebi.atlas.trader.cache.loader;
 
+import org.springframework.stereotype.Component;
 import uk.ac.ebi.atlas.model.experiment.ExperimentType;
-import uk.ac.ebi.atlas.resource.DataFileHub;
 import uk.ac.ebi.atlas.species.SpeciesFactory;
 import uk.ac.ebi.atlas.trader.ConfigurationTrader;
 
-import javax.inject.Inject;
-import javax.inject.Named;
-
-@Named
+@Component
 public class ProteomicsBaselineExperimentFactory extends BaselineExperimentFactory {
-
-    @Inject
     public ProteomicsBaselineExperimentFactory(ConfigurationTrader configurationTrader,
-                                               SpeciesFactory speciesFactory,
-                                               DataFileHub dataFileHub) {
+                                               SpeciesFactory speciesFactory) {
         super(ExperimentType.PROTEOMICS_BASELINE, configurationTrader, speciesFactory);
     }
 }

--- a/gxa/src/main/java/uk/ac/ebi/atlas/trader/cache/loader/RnaSeqBaselineExperimentFactory.java
+++ b/gxa/src/main/java/uk/ac/ebi/atlas/trader/cache/loader/RnaSeqBaselineExperimentFactory.java
@@ -1,16 +1,12 @@
 package uk.ac.ebi.atlas.trader.cache.loader;
 
+import org.springframework.stereotype.Component;
 import uk.ac.ebi.atlas.model.experiment.ExperimentType;
 import uk.ac.ebi.atlas.species.SpeciesFactory;
 import uk.ac.ebi.atlas.trader.ConfigurationTrader;
 
-import javax.inject.Inject;
-import javax.inject.Named;
-
-@Named
+@Component
 public class RnaSeqBaselineExperimentFactory extends BaselineExperimentFactory {
-
-    @Inject
     public RnaSeqBaselineExperimentFactory(ConfigurationTrader configurationTrader,
                                            SpeciesFactory speciesFactory) {
         super(ExperimentType.RNASEQ_MRNA_BASELINE, configurationTrader, speciesFactory);

--- a/gxa/src/test/java/uk/ac/ebi/atlas/trader/cache/loader/BaselineExperimentCacheLoaderTest.java
+++ b/gxa/src/test/java/uk/ac/ebi/atlas/trader/cache/loader/BaselineExperimentCacheLoaderTest.java
@@ -9,6 +9,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.ac.ebi.atlas.experimentimport.ExperimentDTO;
+import uk.ac.ebi.atlas.experimentimport.idf.IdfParserOutput;
 import uk.ac.ebi.atlas.model.AssayGroup;
 import uk.ac.ebi.atlas.model.experiment.ExperimentConfiguration;
 import uk.ac.ebi.atlas.model.experiment.ExperimentDesign;
@@ -63,6 +64,9 @@ public class BaselineExperimentCacheLoaderTest {
     @Mock
     private ExperimentDesign experimentDesign;
 
+    @Mock
+    private IdfParserOutput idfParserOutputMock;
+
     private static MockDataFileHub dataFileHub;
 
     private BaselineExperimentFactory subject;
@@ -111,19 +115,19 @@ public class BaselineExperimentCacheLoaderTest {
     @Test(expected = IllegalStateException.class)
     public void assayGroupsShouldBeNonEmpty() {
         when(configuration.getAssayGroups()).thenReturn(ImmutableList.of());
-        subject.create(dto, experimentDesign);
+        subject.create(dto, experimentDesign, idfParserOutputMock);
     }
 
     @Test
     public void useAllCollaborators() {
-        subject.create(dto, experimentDesign);
+        subject.create(dto, experimentDesign, idfParserOutputMock);
         verifyCollaborators();
         noMoreInteractionsWithCollaborators();
     }
 
     @Test
     public void noAlternativeViewsForTypicalExperiment() {
-        BaselineExperiment e = subject.create(dto, experimentDesign);
+        BaselineExperiment e = subject.create(dto, experimentDesign, idfParserOutputMock);
 
         assertThat(e.alternativeViews(), hasSize(0));
         verifyCollaborators();
@@ -141,7 +145,7 @@ public class BaselineExperimentCacheLoaderTest {
         String s = "default query factor of other experiment";
         when(alternativeViewBaselineConfiguration.getDefaultQueryFactorType()).thenReturn(s);
 
-        BaselineExperiment e = subject.create(dto, experimentDesign);
+        BaselineExperiment e = subject.create(dto, experimentDesign, idfParserOutputMock);
 
         assertThat(e.alternativeViews(), hasSize(1));
         assertThat(e.alternativeViews().get(0).getLeft(), is(alternativeViewAccession));

--- a/gxa/src/test/java/uk/ac/ebi/atlas/trader/cache/loader/BaselineExperimentsCacheLoaderIT.java
+++ b/gxa/src/test/java/uk/ac/ebi/atlas/trader/cache/loader/BaselineExperimentsCacheLoaderIT.java
@@ -11,6 +11,7 @@ import org.springframework.test.context.web.WebAppConfiguration;
 import uk.ac.ebi.atlas.configuration.WebConfig;
 import uk.ac.ebi.atlas.experimentimport.GxaExperimentDao;
 import uk.ac.ebi.atlas.experimentimport.ExperimentDTO;
+import uk.ac.ebi.atlas.experimentimport.idf.IdfParser;
 import uk.ac.ebi.atlas.model.experiment.ExperimentType;
 import uk.ac.ebi.atlas.model.experiment.baseline.BaselineExperiment;
 import uk.ac.ebi.atlas.trader.ExperimentDesignParser;
@@ -42,6 +43,9 @@ public class BaselineExperimentsCacheLoaderIT {
     @Inject
     private ExperimentDesignParser experimentDesignParser;
 
+    @Inject
+    private IdfParser idfParser;
+
     private ExperimentsCacheLoader<BaselineExperiment> subject;
 
     @Before
@@ -59,7 +63,7 @@ public class BaselineExperimentsCacheLoaderIT {
 
         subject =
                 new ExperimentsCacheLoader<>(
-                        experimentDesignParser, expressionAtlasExperimentDao, rnaSeqBaselineExperimentFactory);
+                        experimentDesignParser, expressionAtlasExperimentDao, rnaSeqBaselineExperimentFactory, idfParser);
     }
 
 

--- a/gxa/src/test/java/uk/ac/ebi/atlas/trader/cache/loader/DifferentialExperimentFactoryTest.java
+++ b/gxa/src/test/java/uk/ac/ebi/atlas/trader/cache/loader/DifferentialExperimentFactoryTest.java
@@ -1,0 +1,89 @@
+package uk.ac.ebi.atlas.trader.cache.loader;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.ac.ebi.atlas.experimentimport.ExperimentDTO;
+import uk.ac.ebi.atlas.experimentimport.idf.IdfParserOutput;
+import uk.ac.ebi.atlas.model.AssayGroup;
+import uk.ac.ebi.atlas.model.experiment.ExperimentConfiguration;
+import uk.ac.ebi.atlas.model.experiment.ExperimentDesign;
+import uk.ac.ebi.atlas.model.experiment.baseline.BaselineExperimentConfiguration;
+import uk.ac.ebi.atlas.species.Species;
+import uk.ac.ebi.atlas.species.SpeciesFactory;
+import uk.ac.ebi.atlas.species.SpeciesProperties;
+import uk.ac.ebi.atlas.testutils.RandomDataTestUtils;
+import uk.ac.ebi.atlas.trader.ConfigurationTrader;
+
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class DifferentialExperimentFactoryTest {
+    @Mock
+    private ConfigurationTrader configurationTraderMock;
+
+    @Mock
+    private ExperimentConfiguration configurationMock;
+
+    @Mock
+    private BaselineExperimentConfiguration baselineConfigurationMock;
+
+    @Mock
+    private SpeciesFactory speciesFactoryMock;
+
+    @Mock
+    private ExperimentDTO experimentDtoMock;
+
+    @Mock
+    private IdfParserOutput idfParserOutputMock;
+
+    private DifferentialExperimentFactory subject;
+
+    @BeforeEach
+    void setUp() {
+        when(experimentDtoMock.getSpecies()).thenReturn("Crocubot");
+        when(speciesFactoryMock.create("Crocubot")).thenReturn(new Species("Crocubot", SpeciesProperties.UNKNOWN));
+
+        when(experimentDtoMock.getLastUpdate()).thenReturn(new Date());
+        when(experimentDtoMock.getPubmedIds()).thenReturn(ImmutableSet.of());
+        when(experimentDtoMock.getDois()).thenReturn(ImmutableSet.of());
+
+        when(baselineConfigurationMock.disclaimer()).thenReturn("");
+
+        when(configurationMock.getAssayGroups()).thenReturn(ImmutableList.of(new AssayGroup("Assay X", "X1")));
+
+        when(baselineConfigurationMock.getDefaultFilterFactors()).thenReturn(ImmutableSet.of());
+        when(baselineConfigurationMock.getDefaultQueryFactorType()).thenReturn("SOME_FACTOR");
+        when(baselineConfigurationMock.getMenuFilterFactorTypes()).thenReturn(ImmutableList.of());
+        when(baselineConfigurationMock.getDataProviderURL()).thenReturn(ImmutableList.of());
+        when(baselineConfigurationMock.getDataProviderDescription()).thenReturn(ImmutableList.of());
+
+        subject = new DifferentialExperimentFactory(configurationTraderMock, speciesFactoryMock);
+    }
+
+    @Test
+    void idfTitleOverridesDatabaseTitle() {
+        String experimentAccession = RandomDataTestUtils.getRandomExperimentAccession();
+        when(configurationTraderMock.getExperimentConfiguration(experimentAccession))
+                .thenReturn(configurationMock);
+        when(configurationTraderMock.getBaselineFactorsConfiguration(experimentAccession))
+                .thenReturn(baselineConfigurationMock);
+        when(experimentDtoMock.getExperimentAccession()).thenReturn(experimentAccession);
+
+        when(idfParserOutputMock.getTitle()).thenReturn("IDF " + experimentAccession);
+        when(baselineConfigurationMock.getExperimentDisplayName()).thenReturn("DTO " + experimentAccession);
+
+        assertThat(subject.create(experimentDtoMock, new ExperimentDesign(), idfParserOutputMock))
+                .hasFieldOrPropertyWithValue("description", "IDF " + experimentAccession);
+    }
+}

--- a/gxa/src/test/java/uk/ac/ebi/atlas/trader/cache/loader/DifferentialExperimentsCacheLoaderIT.java
+++ b/gxa/src/test/java/uk/ac/ebi/atlas/trader/cache/loader/DifferentialExperimentsCacheLoaderIT.java
@@ -11,6 +11,7 @@ import org.springframework.test.context.web.WebAppConfiguration;
 import uk.ac.ebi.atlas.configuration.WebConfig;
 import uk.ac.ebi.atlas.experimentimport.GxaExperimentDao;
 import uk.ac.ebi.atlas.experimentimport.ExperimentDTO;
+import uk.ac.ebi.atlas.experimentimport.idf.IdfParser;
 import uk.ac.ebi.atlas.model.AssayGroup;
 import uk.ac.ebi.atlas.model.experiment.ExperimentType;
 import uk.ac.ebi.atlas.model.experiment.differential.Contrast;
@@ -43,6 +44,9 @@ public class DifferentialExperimentsCacheLoaderIT {
     @Inject
     private ExperimentDesignParser experimentDesignParser;
 
+    @Inject
+    private IdfParser idfParser;
+
     private ExperimentsCacheLoader<DifferentialExperiment> subject;
 
     @Before
@@ -55,7 +59,7 @@ public class DifferentialExperimentsCacheLoaderIT {
 
         subject =
                 new ExperimentsCacheLoader<>(
-                        experimentDesignParser, expressionAtlasExperimentDao, differentialExperimentFactory);
+                        experimentDesignParser, expressionAtlasExperimentDao, differentialExperimentFactory, idfParser);
     }
 
     @Test

--- a/gxa/src/test/java/uk/ac/ebi/atlas/trader/cache/loader/MicroarrayExperimentFactoryTest.java
+++ b/gxa/src/test/java/uk/ac/ebi/atlas/trader/cache/loader/MicroarrayExperimentFactoryTest.java
@@ -1,6 +1,8 @@
 package uk.ac.ebi.atlas.trader.cache.loader;
 
 import com.google.common.collect.Sets;
+import org.hamcrest.core.Is;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -21,6 +23,7 @@ import uk.ac.ebi.atlas.trader.ConfigurationTrader;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.when;
 
@@ -76,11 +79,22 @@ public class MicroarrayExperimentFactoryTest {
 
     @Test
     public void testLoad() {
-        MicroarrayExperiment microarrayExperiment = subject.create(experimentDTOMock, experimentDesignMock, idfParserOutputMock);
+        MicroarrayExperiment microarrayExperiment =
+                subject.create(experimentDTOMock, experimentDesignMock, idfParserOutputMock);
         assertThat(microarrayExperiment.getAccession(), is(ACCESSION));
         assertThat(microarrayExperiment.getArrayDesignAccessions(), hasItem(ARRAYDESIGN_ID));
         assertThat(microarrayExperiment.getSpecies(), is(SPECIES));
         assertThat(microarrayExperiment.getExperimentDesign(), is(experimentDesignMock));
         assertThat(microarrayExperiment.getArrayDesignNames(), hasItem(ARRAYDESIGN_NAME));
     }
+
+    @Test
+    public void idfTitleOverridesDatabaseTitleInExperimentDescription() {
+        when(idfParserOutputMock.getTitle()).thenReturn("IDF title");
+        when(experimentDTOMock.getTitle()).thenReturn("DTO title");
+        Assert.assertThat(
+                subject.create(experimentDTOMock, experimentDesignMock, idfParserOutputMock),
+                hasProperty("description", Is.is("IDF title")));
+    }
+
 }

--- a/gxa/src/test/java/uk/ac/ebi/atlas/trader/cache/loader/MicroarrayExperimentFactoryTest.java
+++ b/gxa/src/test/java/uk/ac/ebi/atlas/trader/cache/loader/MicroarrayExperimentFactoryTest.java
@@ -8,6 +8,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.ac.ebi.atlas.dao.ArrayDesignDAO;
 import uk.ac.ebi.atlas.experimentimport.ExperimentDTO;
+import uk.ac.ebi.atlas.experimentimport.idf.IdfParserOutput;
 import uk.ac.ebi.atlas.model.ArrayDesign;
 import uk.ac.ebi.atlas.model.experiment.ExperimentDesign;
 import uk.ac.ebi.atlas.model.experiment.ExperimentType;
@@ -47,6 +48,9 @@ public class MicroarrayExperimentFactoryTest {
     private ExperimentDesign experimentDesignMock;
 
     @Mock
+    private IdfParserOutput idfParserOutputMock;
+
+    @Mock
     private ArrayDesignDAO arrayDesignDAO;
 
     private MicroarrayExperimentFactory subject;
@@ -72,7 +76,7 @@ public class MicroarrayExperimentFactoryTest {
 
     @Test
     public void testLoad() {
-        MicroarrayExperiment microarrayExperiment = subject.create(experimentDTOMock, experimentDesignMock);
+        MicroarrayExperiment microarrayExperiment = subject.create(experimentDTOMock, experimentDesignMock, idfParserOutputMock);
         assertThat(microarrayExperiment.getAccession(), is(ACCESSION));
         assertThat(microarrayExperiment.getArrayDesignAccessions(), hasItem(ARRAYDESIGN_ID));
         assertThat(microarrayExperiment.getSpecies(), is(SPECIES));

--- a/gxa/src/test/java/uk/ac/ebi/atlas/trader/cache/loader/ProteomicsBaselineExperimentFactoryTest.java
+++ b/gxa/src/test/java/uk/ac/ebi/atlas/trader/cache/loader/ProteomicsBaselineExperimentFactoryTest.java
@@ -1,0 +1,89 @@
+package uk.ac.ebi.atlas.trader.cache.loader;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.ac.ebi.atlas.experimentimport.ExperimentDTO;
+import uk.ac.ebi.atlas.experimentimport.idf.IdfParserOutput;
+import uk.ac.ebi.atlas.model.AssayGroup;
+import uk.ac.ebi.atlas.model.experiment.ExperimentConfiguration;
+import uk.ac.ebi.atlas.model.experiment.ExperimentDesign;
+import uk.ac.ebi.atlas.model.experiment.baseline.BaselineExperimentConfiguration;
+import uk.ac.ebi.atlas.species.Species;
+import uk.ac.ebi.atlas.species.SpeciesFactory;
+import uk.ac.ebi.atlas.species.SpeciesProperties;
+import uk.ac.ebi.atlas.testutils.RandomDataTestUtils;
+import uk.ac.ebi.atlas.trader.ConfigurationTrader;
+
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ProteomicsBaselineExperimentFactoryTest {
+    @Mock
+    private ConfigurationTrader configurationTraderMock;
+
+    @Mock
+    private ExperimentConfiguration configurationMock;
+
+    @Mock
+    private BaselineExperimentConfiguration baselineConfigurationMock;
+
+    @Mock
+    private SpeciesFactory speciesFactoryMock;
+
+    @Mock
+    private ExperimentDTO experimentDtoMock;
+
+    @Mock
+    private IdfParserOutput idfParserOutputMock;
+
+    private ProteomicsBaselineExperimentFactory subject;
+
+    @BeforeEach
+    void setUp() {
+        when(experimentDtoMock.getSpecies()).thenReturn("Crocubot");
+        when(speciesFactoryMock.create("Crocubot")).thenReturn(new Species("Crocubot", SpeciesProperties.UNKNOWN));
+
+        when(experimentDtoMock.getLastUpdate()).thenReturn(new Date());
+        when(experimentDtoMock.getPubmedIds()).thenReturn(ImmutableSet.of());
+        when(experimentDtoMock.getDois()).thenReturn(ImmutableSet.of());
+
+        when(baselineConfigurationMock.disclaimer()).thenReturn("");
+
+        when(configurationMock.getAssayGroups()).thenReturn(ImmutableList.of(new AssayGroup("Assay X", "X1")));
+
+        when(baselineConfigurationMock.getDefaultFilterFactors()).thenReturn(ImmutableSet.of());
+        when(baselineConfigurationMock.getDefaultQueryFactorType()).thenReturn("SOME_FACTOR");
+        when(baselineConfigurationMock.getMenuFilterFactorTypes()).thenReturn(ImmutableList.of());
+        when(baselineConfigurationMock.getDataProviderURL()).thenReturn(ImmutableList.of());
+        when(baselineConfigurationMock.getDataProviderDescription()).thenReturn(ImmutableList.of());
+
+        subject = new ProteomicsBaselineExperimentFactory(configurationTraderMock, speciesFactoryMock);
+    }
+
+    @Test
+    void idfTitleOverridesDatabaseTitle() {
+        String experimentAccession = RandomDataTestUtils.getRandomExperimentAccession();
+        when(configurationTraderMock.getExperimentConfiguration(experimentAccession))
+                .thenReturn(configurationMock);
+        when(configurationTraderMock.getBaselineFactorsConfiguration(experimentAccession))
+                .thenReturn(baselineConfigurationMock);
+        when(experimentDtoMock.getExperimentAccession()).thenReturn(experimentAccession);
+
+        when(idfParserOutputMock.getTitle()).thenReturn("IDF " + experimentAccession);
+        when(baselineConfigurationMock.getExperimentDisplayName()).thenReturn("DTO " + experimentAccession);
+
+        assertThat(subject.create(experimentDtoMock, new ExperimentDesign(), idfParserOutputMock))
+                .hasFieldOrPropertyWithValue("description", "IDF " + experimentAccession);
+    }
+}

--- a/gxa/src/test/java/uk/ac/ebi/atlas/trader/cache/loader/ProteomicsBaselineExperimentsCacheLoaderIT.java
+++ b/gxa/src/test/java/uk/ac/ebi/atlas/trader/cache/loader/ProteomicsBaselineExperimentsCacheLoaderIT.java
@@ -11,6 +11,7 @@ import org.springframework.test.context.web.WebAppConfiguration;
 import uk.ac.ebi.atlas.configuration.WebConfig;
 import uk.ac.ebi.atlas.experimentimport.GxaExperimentDao;
 import uk.ac.ebi.atlas.experimentimport.ExperimentDTO;
+import uk.ac.ebi.atlas.experimentimport.idf.IdfParser;
 import uk.ac.ebi.atlas.model.AssayGroup;
 import uk.ac.ebi.atlas.model.experiment.ExperimentDesign;
 import uk.ac.ebi.atlas.model.experiment.ExperimentType;
@@ -54,6 +55,9 @@ public class ProteomicsBaselineExperimentsCacheLoaderIT {
     @Inject
     private ExperimentDesignParser experimentDesignParser;
 
+    @Inject
+    private IdfParser idfParser;
+
     private ExperimentsCacheLoader<BaselineExperiment> subject;
 
     @Before
@@ -74,7 +78,7 @@ public class ProteomicsBaselineExperimentsCacheLoaderIT {
 
         subject =
                 new ExperimentsCacheLoader<>(
-                        experimentDesignParser, expressionAtlasExperimentDao, proteomicsBaselineExperimentFactory);
+                        experimentDesignParser, expressionAtlasExperimentDao, proteomicsBaselineExperimentFactory, idfParser);
     }
 
     @Test

--- a/gxa/src/test/java/uk/ac/ebi/atlas/trader/cache/loader/RnaSeqBaselineExperimentFactoryTest.java
+++ b/gxa/src/test/java/uk/ac/ebi/atlas/trader/cache/loader/RnaSeqBaselineExperimentFactoryTest.java
@@ -1,0 +1,89 @@
+package uk.ac.ebi.atlas.trader.cache.loader;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.ac.ebi.atlas.experimentimport.ExperimentDTO;
+import uk.ac.ebi.atlas.experimentimport.idf.IdfParserOutput;
+import uk.ac.ebi.atlas.model.AssayGroup;
+import uk.ac.ebi.atlas.model.experiment.ExperimentConfiguration;
+import uk.ac.ebi.atlas.model.experiment.ExperimentDesign;
+import uk.ac.ebi.atlas.model.experiment.baseline.BaselineExperimentConfiguration;
+import uk.ac.ebi.atlas.species.Species;
+import uk.ac.ebi.atlas.species.SpeciesFactory;
+import uk.ac.ebi.atlas.species.SpeciesProperties;
+import uk.ac.ebi.atlas.testutils.RandomDataTestUtils;
+import uk.ac.ebi.atlas.trader.ConfigurationTrader;
+
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class RnaSeqBaselineExperimentFactoryTest {
+    @Mock
+    private ConfigurationTrader configurationTraderMock;
+
+    @Mock
+    private ExperimentConfiguration configurationMock;
+
+    @Mock
+    private BaselineExperimentConfiguration baselineConfigurationMock;
+
+    @Mock
+    private SpeciesFactory speciesFactoryMock;
+
+    @Mock
+    private ExperimentDTO experimentDtoMock;
+
+    @Mock
+    private IdfParserOutput idfParserOutputMock;
+
+    private RnaSeqBaselineExperimentFactory subject;
+
+    @BeforeEach
+    void setUp() {
+        when(experimentDtoMock.getSpecies()).thenReturn("Crocubot");
+        when(speciesFactoryMock.create("Crocubot")).thenReturn(new Species("Crocubot", SpeciesProperties.UNKNOWN));
+
+        when(experimentDtoMock.getLastUpdate()).thenReturn(new Date());
+        when(experimentDtoMock.getPubmedIds()).thenReturn(ImmutableSet.of());
+        when(experimentDtoMock.getDois()).thenReturn(ImmutableSet.of());
+
+        when(baselineConfigurationMock.disclaimer()).thenReturn("");
+
+        when(configurationMock.getAssayGroups()).thenReturn(ImmutableList.of(new AssayGroup("Assay X", "X1")));
+
+        when(baselineConfigurationMock.getDefaultFilterFactors()).thenReturn(ImmutableSet.of());
+        when(baselineConfigurationMock.getDefaultQueryFactorType()).thenReturn("SOME_FACTOR");
+        when(baselineConfigurationMock.getMenuFilterFactorTypes()).thenReturn(ImmutableList.of());
+        when(baselineConfigurationMock.getDataProviderURL()).thenReturn(ImmutableList.of());
+        when(baselineConfigurationMock.getDataProviderDescription()).thenReturn(ImmutableList.of());
+
+        subject = new RnaSeqBaselineExperimentFactory(configurationTraderMock, speciesFactoryMock);
+    }
+
+    @Test
+    void idfTitleOverridesDatabaseTitle() {
+        String experimentAccession = RandomDataTestUtils.getRandomExperimentAccession();
+        when(configurationTraderMock.getExperimentConfiguration(experimentAccession))
+                .thenReturn(configurationMock);
+        when(configurationTraderMock.getBaselineFactorsConfiguration(experimentAccession))
+                .thenReturn(baselineConfigurationMock);
+        when(experimentDtoMock.getExperimentAccession()).thenReturn(experimentAccession);
+
+        when(idfParserOutputMock.getTitle()).thenReturn("IDF " + experimentAccession);
+        when(baselineConfigurationMock.getExperimentDisplayName()).thenReturn("DTO " + experimentAccession);
+
+        assertThat(subject.create(experimentDtoMock, new ExperimentDesign(), idfParserOutputMock))
+                .hasFieldOrPropertyWithValue("description", "IDF " + experimentAccession);
+    }
+}

--- a/sc/src/main/java/uk/ac/ebi/atlas/trader/ScxaExperimentTrader.java
+++ b/sc/src/main/java/uk/ac/ebi/atlas/trader/ScxaExperimentTrader.java
@@ -3,6 +3,7 @@ package uk.ac.ebi.atlas.trader;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.LoadingCache;
 import uk.ac.ebi.atlas.experimentimport.ScxaExperimentDao;
+import uk.ac.ebi.atlas.experimentimport.idf.IdfParser;
 import uk.ac.ebi.atlas.model.experiment.Experiment;
 import uk.ac.ebi.atlas.model.experiment.ExperimentType;
 import uk.ac.ebi.atlas.model.experiment.baseline.Cell;
@@ -21,12 +22,13 @@ public class ScxaExperimentTrader extends ExperimentTrader {
     @Inject
     public ScxaExperimentTrader(ScxaExperimentDao experimentDao,
                                 SingleCellRnaSeqBaselineExperimentFactory experimentFactory,
-                                ExperimentDesignParser experimentDesignParser) {
+                                ExperimentDesignParser experimentDesignParser,
+                                IdfParser idfParser) {
         super(experimentDao);
         baselineExperimentsCache =
                 CacheBuilder.newBuilder().build(
                         new ExperimentsCacheLoader<>(
-                                experimentDesignParser, experimentDao, experimentFactory));
+                                experimentDesignParser, experimentDao, experimentFactory, idfParser));
     }
 
     public Experiment<Cell> getPublicExperiment(String experimentAccession) {

--- a/sc/src/main/java/uk/ac/ebi/atlas/trader/cache/loader/SingleCellBaselineExperimentFactory.java
+++ b/sc/src/main/java/uk/ac/ebi/atlas/trader/cache/loader/SingleCellBaselineExperimentFactory.java
@@ -1,6 +1,7 @@
 package uk.ac.ebi.atlas.trader.cache.loader;
 
 import uk.ac.ebi.atlas.experimentimport.ExperimentDTO;
+import uk.ac.ebi.atlas.experimentimport.idf.IdfParserOutput;
 import uk.ac.ebi.atlas.model.experiment.ExperimentDesign;
 import uk.ac.ebi.atlas.model.experiment.ExperimentType;
 import uk.ac.ebi.atlas.model.experiment.baseline.Cell;
@@ -23,7 +24,8 @@ public abstract class SingleCellBaselineExperimentFactory implements ExperimentF
 
     @Override
     public SingleCellBaselineExperiment create(ExperimentDTO experimentDTO,
-                                     ExperimentDesign experimentDesign) {
+                                               ExperimentDesign experimentDesign,
+                                               IdfParserOutput idfParserOutput) {
 
         String experimentAccession = experimentDTO.getExperimentAccession();
 
@@ -32,7 +34,7 @@ public abstract class SingleCellBaselineExperimentFactory implements ExperimentF
                 .forSpecies(speciesFactory.create(experimentDTO.getSpecies()))
                 .withAccession(experimentAccession)
                 .withLastUpdate(experimentDTO.getLastUpdate())
-                .withDescription(experimentDTO.getTitle())
+                .withDescription(idfParserOutput.getTitle())
                 .withPubMedIds(experimentDTO.getPubmedIds())
                 .withDois(experimentDTO.getDois())
                 .withCells(experimentDesign.getAllRunOrAssay().stream().map(Cell::new).collect(Collectors.toList()))


### PR DESCRIPTION
- Added `IdfParser` to the `ExperimentsCacheLoader` class
- Added `IdfParserOutput` to the `ExperimentFactory` classes
- Replacing title from the `ExperimentDTO` (i.e. from the database) with the one read from the idf file