### PR TITLE
Bugfix #160415041 - No info retrieved for gene IDs with dot suffixes

### DIFF
--- a/base/src/main/java/uk/ac/ebi/atlas/testutils/SolrUtils.java
+++ b/base/src/main/java/uk/ac/ebi/atlas/testutils/SolrUtils.java
@@ -3,11 +3,12 @@ package uk.ac.ebi.atlas.testutils;
 import org.springframework.stereotype.Component;
 import uk.ac.ebi.atlas.solr.cloud.SolrCloudCollectionProxyFactory;
 import uk.ac.ebi.atlas.solr.cloud.collections.AnalyticsCollectionProxy;
+import uk.ac.ebi.atlas.solr.cloud.collections.BioentitiesCollectionProxy;
 import uk.ac.ebi.atlas.solr.cloud.search.SolrQueryBuilder;
 
 import java.util.concurrent.ThreadLocalRandom;
 
-import static uk.ac.ebi.atlas.solr.cloud.collections.AnalyticsCollectionProxy.BIOENTITY_IDENTIFIER;
+import static uk.ac.ebi.atlas.solr.cloud.collections.BioentitiesCollectionProxy.SPECIES;
 
 @Component
 public class SolrUtils {
@@ -24,9 +25,24 @@ public class SolrUtils {
         AnalyticsCollectionProxy analyticsCollectionProxy =
                 solrCloudCollectionProxyFactory.create(AnalyticsCollectionProxy.class);
         SolrQueryBuilder<AnalyticsCollectionProxy> queryBuilder = new SolrQueryBuilder<>();
-        queryBuilder.setFieldList(BIOENTITY_IDENTIFIER);
+        queryBuilder.setFieldList(AnalyticsCollectionProxy.BIOENTITY_IDENTIFIER);
         queryBuilder.setRows(MAX_ROWS);
         return analyticsCollectionProxy
+                .query(queryBuilder)
+                .getResults()
+                .get(RNG.nextInt(MAX_ROWS))
+                .getFieldValue("bioentity_identifier")
+                .toString();
+    }
+
+    public String fetchRandomGeneOfSpecies(String species) {
+        BioentitiesCollectionProxy bioentitiesCollectionProxy =
+                solrCloudCollectionProxyFactory.create(BioentitiesCollectionProxy.class);
+        SolrQueryBuilder<BioentitiesCollectionProxy> queryBuilder = new SolrQueryBuilder<>();
+        queryBuilder.addFilterFieldByTerm(SPECIES, species);
+        queryBuilder.setFieldList(BioentitiesCollectionProxy.BIOENTITY_IDENTIFIER);
+        queryBuilder.setRows(MAX_ROWS);
+        return bioentitiesCollectionProxy
                 .query(queryBuilder)
                 .getResults()
                 .get(RNG.nextInt(MAX_ROWS))

--- a/gxa/src/main/java/uk/ac/ebi/atlas/search/JsonBioentityInformationController.java
+++ b/gxa/src/main/java/uk/ac/ebi/atlas/search/JsonBioentityInformationController.java
@@ -37,7 +37,7 @@ public class JsonBioentityInformationController extends JsonExceptionHandlingCon
     }
 
     @RequestMapping(
-            value = "/json/bioentity_information/{geneId}",
+            value = "/json/bioentity_information/{geneId:.+}", // Don't truncate ".value" at the end of IDs
             method = RequestMethod.GET,
             produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
     public String getBioentityInformation(@PathVariable String geneId) {

--- a/gxa/src/test/java/uk/ac/ebi/atlas/search/JsonBioentityInformationControllerWIT.java
+++ b/gxa/src/test/java/uk/ac/ebi/atlas/search/JsonBioentityInformationControllerWIT.java
@@ -1,12 +1,12 @@
 package uk.ac.ebi.atlas.search;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -24,7 +24,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @WebAppConfiguration
 @ContextConfiguration(classes = WebConfig.class)
 public class JsonBioentityInformationControllerWIT {
@@ -36,7 +36,9 @@ public class JsonBioentityInformationControllerWIT {
 
     private MockMvc mockMvc;
 
-    @Before
+    private static final String urlTemplate = "/json/bioentity_information/{geneId}";
+
+    @BeforeEach
     public void setUp() {
         this.mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
     }
@@ -46,7 +48,7 @@ public class JsonBioentityInformationControllerWIT {
         String geneId = solrUtils.fetchRandomGeneFromAnalytics();
 
         this.mockMvc
-                .perform(get("/json/bioentity_information/" + geneId))
+                .perform(get(urlTemplate, geneId))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
                 .andExpect(jsonPath("$[0].type", isA(String.class)))
@@ -58,9 +60,21 @@ public class JsonBioentityInformationControllerWIT {
     }
 
     @Test
+    public void geneIdContainingDotIsNotTruncated() throws Exception {
+        String geneId = solrUtils.fetchRandomGeneOfSpecies("Arabidopsis_lyrata"); // has gene IDs containing dots
+
+        if(!geneId.isEmpty()) {
+            this.mockMvc
+                    .perform(get(urlTemplate, geneId))
+                    .andExpect(status().isOk())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8));
+        }
+    }
+
+    @Test
     public void geneNotFound() throws Exception {
         this.mockMvc
-                .perform(get("/json/bioentity_information/unknown"))
+                .perform(get(urlTemplate ,"unknown"))
                 .andExpect(status().isNotFound());
     }
 }

--- a/sc/src/main/java/uk/ac/ebi/atlas/search/JsonBioentityInformationController.java
+++ b/sc/src/main/java/uk/ac/ebi/atlas/search/JsonBioentityInformationController.java
@@ -40,7 +40,7 @@ public class JsonBioentityInformationController extends JsonExceptionHandlingCon
     }
 
     @RequestMapping(
-            value = "/json/bioentity_information/{geneId}",
+            value = "/json/bioentity_information/{geneId:.+}",
             method = RequestMethod.GET,
             produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
     public String getBioentityInformation(@PathVariable String geneId) {


### PR DESCRIPTION
- Implemented fix for gene IDs such as `scaffold_105660.1` were truncated by Spring.
- Added additional test cases.